### PR TITLE
V0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # PointyApi Changelog
 
+## [0.3.1] Dec-02-2018 - Minor Bugfixes
+
+Fixed JWT Token expiration & __orderBy
+
+### Fixes
+- [Issue #57] __orderBy should prepend 'obj' to column name
+- [Issue #56] JWT Expiration is in milliseconds rather than seconds
+
 ## [0.3.0] Dec-01-2018 - Search Update
 
 Added options to GET search, fixed filters, and return expiration with token.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"author": "stateless-studio",
 	"license": "MIT",
 	"scripts": {

--- a/src/jwt-bearer.ts
+++ b/src/jwt-bearer.ts
@@ -34,7 +34,7 @@ class JwtBearer {
 	public sign(user: BaseUser) {
 		return btoa(
 			JWT.sign({ id: user.id }, this.key, {
-				expiresIn: process.env.JWT_TTL
+				expiresIn: parseInt(process.env.JWT_TTL, 10)
 			})
 		);
 	}

--- a/src/middleware/get-query.ts
+++ b/src/middleware/get-query.ts
@@ -211,7 +211,7 @@ export async function getQuery(
 		const orderByOrders = [];
 		if ('__orderBy' in request.query) {
 			for (const key in request.query.__orderBy) {
-				orderByKeys.push(key);
+				orderByKeys.push(objMnemonic + '.' + key);
 				orderByOrders.push(
 					request.query.__orderBy[key] === 'DESC' ? 'DESC' : 'ASC'
 				);


### PR DESCRIPTION
## [0.3.1] Dec-02-2018 - Minor Bugfixes

Fixed JWT Token expiration & __orderBy

### Fixes
- [Issue #57] __orderBy should prepend 'obj' to column name
- [Issue #56] JWT Expiration is in milliseconds rather than seconds