### PR TITLE
V0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # PointyApi Changelog
 
+## [0.5.0] Dec-31-2018
+
+Created `CanSearchRelation()` decorator and fixed relation search bugs
+
+### Additions
+- Created `CanSearchRelation()` ([Issue #68] Must be able to search by joined columns)
+
+### Fixes
+- [Issue #67] GET query fails on order by joined column
+- [Issue #66] GET query must query by bodyguard keys, unless user is admin
+
 ## [0.4.2] Dec-26-2018
 
 Fixed onlySelf() on GET

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "0.4.2",
+	"version": "0.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -258,7 +258,7 @@
 		},
 		"array-flatten": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
 		"array-from": {
@@ -583,7 +583,7 @@
 		},
 		"content-disposition": {
 			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
 			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
 		},
 		"content-type": {
@@ -1869,7 +1869,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
@@ -2257,7 +2257,7 @@
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
 						"code-point-at": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "0.4.2",
+	"version": "0.5.0",
 	"author": "stateless-studio",
 	"license": "MIT",
 	"scripts": {

--- a/src/bodyguard.ts
+++ b/src/bodyguard.ts
@@ -141,6 +141,7 @@ const CanReadSymbol = Symbol('CanRead');
 const CanWriteSymbol = Symbol('CanWrite');
 const BodyguardKeySymbol = Symbol('BodyguardKey');
 const CanSearchSymbol = Symbol('CanSearch');
+const CanSearchRelationSymbol = Symbol('CanSearchRelation');
 
 export function isBodyguardKey(target: any, propertyKey: string) {
 	return Reflect.getMetadata(BodyguardKeySymbol, target, propertyKey);
@@ -156,6 +157,10 @@ export function getCanWrite(target: any, propertyKey: string) {
 
 export function getCanSearch(target: any, propertyKey: string) {
 	return Reflect.getMetadata(CanSearchSymbol, target, propertyKey);
+}
+
+export function getCanSearchRelation(target: any, propertyKey: string) {
+	return Reflect.getMetadata(CanSearchRelationSymbol, target, propertyKey);
 }
 
 export function BodyguardKey() {
@@ -198,6 +203,10 @@ export function CanSearch(who: string = '__anyone__') {
 	return Reflect.metadata(CanSearchSymbol, who);
 }
 
+export function CanSearchRelation(params: object) {
+	return Reflect.metadata(CanSearchRelationSymbol, params);
+}
+
 export { isAdmin } from './bodyguard/is-admin';
 export { isSelf } from './bodyguard/is-self';
 
@@ -205,6 +214,7 @@ export { compareNestedBodyguards } from './bodyguard/compare-nested';
 export { compareIdToUser } from './bodyguard/compare-id-to-user';
 export { getBodyguardKeys } from './bodyguard/get-bodyguard-keys';
 export { getSearchableFields } from './bodyguard/get-searchable-fields';
+export { getSearchableRelations } from './bodyguard/get-searchable-relations';
 export { getReadableFields } from './bodyguard/get-readable-fields';
 
 export { responseFilter } from './bodyguard/response-filter';

--- a/src/bodyguard/get-searchable-relations.ts
+++ b/src/bodyguard/get-searchable-relations.ts
@@ -1,0 +1,26 @@
+import { getCanSearchRelation } from '../bodyguard';
+import { BaseModel } from '../models';
+
+/**
+ * Get an array of searchable fields for the object
+ * @param obj Object to receive keys for
+ * @param user User object to check for permissions
+ */
+export function getSearchableRelations(obj: BaseModel): string[] {
+	let searchableFields: string[] = [];
+
+	for (const member in obj) {
+		const canSearchRelation = getCanSearchRelation(obj, member);
+
+		if (canSearchRelation) {
+			const who = canSearchRelation.who;
+			const fields = canSearchRelation.fields.map((field) => {
+				return `${member}.${field}`;
+			});
+
+			searchableFields = searchableFields.concat(fields);
+		}
+	}
+
+	return searchableFields;
+}

--- a/src/middleware/get-query.ts
+++ b/src/middleware/get-query.ts
@@ -223,7 +223,7 @@ export async function getQuery(
 		const orderByOrders = [];
 		if ('__orderBy' in request.query) {
 			for (const key in request.query.__orderBy) {
-				orderByKeys.push(objMnemonic + '.' + key);
+				orderByKeys.push(key);
 				orderByOrders.push(
 					request.query.__orderBy[key] === 'DESC' ? 'DESC' : 'ASC'
 				);

--- a/src/middleware/get-query.ts
+++ b/src/middleware/get-query.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import {
 	getSearchableFields,
+	getSearchableRelations,
 	getReadableFields,
 	getBodyguardKeys
 } from '../bodyguard';
@@ -9,6 +10,7 @@ import { UserRole } from '../enums/user-role';
 
 function createSearchQuery(payloadType, obj: Object, objKey: string = 'obj') {
 	const searchableFields = getSearchableFields(payloadType);
+	const searchableRelations = getSearchableRelations(payloadType);
 	let queryString = '';
 	const queryParams = {};
 	const hasSearchable = searchableFields.length;
@@ -25,6 +27,15 @@ function createSearchQuery(payloadType, obj: Object, objKey: string = 'obj') {
 		searchableFields.forEach((field) => {
 			// Append searchable key to queryString
 			queryString += `${objKey}.${field} LIKE :__search OR `;
+
+			// Append parameter to queryParams (with wildcards)
+			const value = obj['__search'].replace(/[\s]+/, '%');
+			queryParams['__search'] = `%${value}%`;
+		});
+
+		searchableRelations.forEach((field) => {
+			// Append searchable key to queryString
+			queryString += `${field} LIKE :__search OR `;
 
 			// Append parameter to queryParams (with wildcards)
 			const value = obj['__search'].replace(/[\s]+/, '%');

--- a/src/middleware/get-query.ts
+++ b/src/middleware/get-query.ts
@@ -5,6 +5,7 @@ import {
 	getBodyguardKeys
 } from '../bodyguard';
 import { runHook } from '../run-hook';
+import { UserRole } from '../enums/user-role';
 
 function createSearchQuery(payloadType, obj: Object, objKey: string = 'obj') {
 	const searchableFields = getSearchableFields(payloadType);
@@ -268,7 +269,7 @@ export async function getQuery(
 			});
 
 			// Append to where clause
-			if (bodyguardKeys) {
+			if (bodyguardKeys && request.user.role !== UserRole.Admin) {
 				queryString += ` AND (`;
 				bodyguardKeys.forEach((key) => {
 					queryString += `obj.${key}=:bodyGuard${key} OR `;

--- a/src/middleware/get-query.ts
+++ b/src/middleware/get-query.ts
@@ -269,7 +269,11 @@ export async function getQuery(
 			});
 
 			// Append to where clause
-			if (bodyguardKeys && request.user.role !== UserRole.Admin) {
+			if (
+				bodyguardKeys &&
+				request.user &&
+				request.user.role !== UserRole.Admin
+			) {
 				queryString += ` AND (`;
 				bodyguardKeys.forEach((key) => {
 					queryString += `obj.${key}=:bodyGuard${key} OR `;

--- a/src/middleware/get-query.ts
+++ b/src/middleware/get-query.ts
@@ -276,7 +276,7 @@ export async function getQuery(
 			) {
 				queryString += ` AND (`;
 				bodyguardKeys.forEach((key) => {
-					queryString += `obj.${key}=:bodyGuard${key} OR `;
+					queryString += `${objMnemonic}.${key}=:bodyGuard${key} OR `;
 
 					queryParams['bodyGuard' + key] = request.user.id;
 				});

--- a/test/examples/chat/models/chat-message.ts
+++ b/test/examples/chat/models/chat-message.ts
@@ -19,7 +19,9 @@ import {
 	OnlySelfCanWrite,
 	OnlyAdminCanWrite,
 	BodyguardKey,
-	CanSearch
+	CanSearch,
+	CanSearchRelation,
+	getSearchableFields
 } from '../../../../src/bodyguard';
 
 // Models
@@ -43,6 +45,10 @@ export class ChatMessage extends BaseModel {
 	@BodyguardKey()
 	@OnlySelfCanRead()
 	@OnlySelfCanWrite()
+	@CanSearchRelation({
+		who: '__self__',
+		fields: [ 'username', 'fname', 'lname' ]
+	})
 	public from: User = undefined;
 
 	// To User
@@ -54,6 +60,10 @@ export class ChatMessage extends BaseModel {
 	@BodyguardKey()
 	@OnlySelfCanRead()
 	@OnlySelfCanWrite()
+	@CanSearchRelation({
+		who: '__self__',
+		fields: [ 'username', 'fname', 'lname' ]
+	})
 	public to: User = undefined;
 
 	// Time created

--- a/test/spec/chat/chat/chat-get.spec.ts
+++ b/test/spec/chat/chat/chat-get.spec.ts
@@ -393,4 +393,42 @@ describe('[Chat] Chat API Get', async () => {
 			fail('Could not create base user =and/or chat');
 		}
 	});
+
+	it('can sort by nested objects', async () => {
+		await http
+			.get(
+				'/api/v1/chat',
+				{
+					__search: '',
+					__orderBy: {
+						'from.username': 'DESC'
+					}
+				},
+				[ 200 ],
+				this.token.body.token
+			)
+			.then((result) => {
+				if (result.body instanceof Array) {
+					expect(result.body.length).toBeGreaterThanOrEqual(2);
+
+					let firstId;
+					let secondId;
+
+					result.body.forEach((chat, i) => {
+						if (i === 0) {
+							firstId = chat.from.id;
+						}
+						else if (i === 1) {
+							secondId = chat.from.id;
+						}
+					});
+
+					expect(firstId).toBeGreaterThan(secondId);
+				}
+				else {
+					fail('Result is not an array');
+				}
+			})
+			.catch((error) => fail(JSON.stringify(error)));
+	});
 });


### PR DESCRIPTION
## [0.5.0] Dec-31-2018

Created `CanSearchRelation()` decorator and fixed relation search bugs

### Additions
- Created `CanSearchRelation()` ([Issue #68] Must be able to search by joined columns)

### Fixes
- [Issue #67] GET query fails on order by joined column
- [Issue #66] GET query must query by bodyguard keys, unless user is admin