### PR TITLE
V0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PointyApi Changelog
 
+## [0.5.1] Dec-31-2018
+
+### Fixes
+- [Issue #71] Object alias (mnemonic) must be prepended if join tables exist, but this field isn't from a join
+
 ## [0.5.0] Dec-31-2018
 
 Created `CanSearchRelation()` decorator and fixed relation search bugs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"author": "stateless-studio",
 	"license": "MIT",
 	"scripts": {

--- a/src/middleware/get-query.ts
+++ b/src/middleware/get-query.ts
@@ -303,6 +303,7 @@ export async function getQuery(
 			.select(readableFields);
 
 		// Loop through join tables
+		const hasJoinMembers = request.joinMembers.length > 0;
 		for (const table of request.joinMembers) {
 			selection = await selection.leftJoinAndSelect(
 				`${objMnemonic}.${table}`,
@@ -321,7 +322,15 @@ export async function getQuery(
 
 			// Add order by keys
 			for (let i = 0; i < orderByKeys.length; i++) {
-				query.addOrderBy(orderByKeys[i], orderByOrders[i]);
+				let key = orderByKeys[i];
+
+				// Object alias must be prepended if join tables exist,
+				// but this field isn't from a join
+				if (hasJoinMembers && !key.includes('.')) {
+					key = 'obj.' + key;
+				}
+
+				query.addOrderBy(key, orderByOrders[i]);
 			}
 
 			// Add limit

--- a/test/spec/chat/chat/chat-get.spec.ts
+++ b/test/spec/chat/chat/chat-get.spec.ts
@@ -431,4 +431,28 @@ describe('[Chat] Chat API Get', async () => {
 			})
 			.catch((error) => fail(JSON.stringify(error)));
 	});
+
+	it('can sort by member when a join column is included', async () => {
+		await http
+			.get(
+				'/api/v1/chat',
+				{
+					__search: '',
+					__orderBy: {
+						id: 'ASC'
+					}
+				},
+				[ 200 ],
+				this.token.body.token
+			)
+			.then((result) => {
+				if (result.body instanceof Array) {
+					expect(result.body.length).toBeGreaterThanOrEqual(2);
+				}
+				else {
+					fail('Result is not an array');
+				}
+			})
+			.catch((error) => JSON.stringify(error));
+	});
 });


### PR DESCRIPTION
## [0.5.1] Dec-31-2018

### Fixes
- [Issue #71] Object alias (mnemonic) must be prepended if join tables exist, but this field isn't from a join