### PR TITLE
V0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PointyApi Changelog
 
+## [0.5.2] Dec-31-2018
+
+### Fixes
+- [Issue #73] Object alias should be prepended to order by key regardless of joins
+
 ## [0.5.1] Dec-31-2018
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"author": "stateless-studio",
 	"license": "MIT",
 	"scripts": {

--- a/src/middleware/get-query.ts
+++ b/src/middleware/get-query.ts
@@ -303,7 +303,6 @@ export async function getQuery(
 			.select(readableFields);
 
 		// Loop through join tables
-		const hasJoinMembers = request.joinMembers.length > 0;
 		for (const table of request.joinMembers) {
 			selection = await selection.leftJoinAndSelect(
 				`${objMnemonic}.${table}`,
@@ -326,7 +325,7 @@ export async function getQuery(
 
 				// Object alias must be prepended if join tables exist,
 				// but this field isn't from a join
-				if (hasJoinMembers && !key.includes('.')) {
+				if (!key.includes('.')) {
 					key = 'obj.' + key;
 				}
 


### PR DESCRIPTION
## [0.5.2] Dec-31-2018

### Fixes
- [Issue #73] Object alias should be prepended to order by key regardless of joins