### PR TITLE
V1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # PointyApi Changelog
 
+## [1.1.1] Mar-04-2019
+
+### Fixes
+- Added CanReadRelation() on Term end of termRelations
+- Removed AnyoneCanRead() from User termRelations
+- Removed select query from Term relationship test
+- Added get one test to Term relationship test suite
+
 ## [1.1.0] Mar-04-2019
 
 ### Additions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"author": "stateless-studio",
 	"license": "MIT",
 	"scripts": {

--- a/test/examples/terms/models/term.ts
+++ b/test/examples/terms/models/term.ts
@@ -22,7 +22,8 @@ import {
 	OnlyAdminCanWrite,
 	BodyguardKey,
 	CanSearch,
-	CanSearchRelation
+	CanSearchRelation,
+	CanReadRelation
 } from '../../../../src/bodyguard';
 import { BodyguardOwner } from '../../../../src/enums';
 
@@ -46,6 +47,7 @@ export class Term extends BaseModel {
 	public author: User = undefined;
 
 	@ManyToMany((type) => User, (user) => user.termRelations)
+	@CanReadRelation()
 	public users: User[] = undefined;
 
 	@Column({ default: false })

--- a/test/examples/terms/models/user.ts
+++ b/test/examples/terms/models/user.ts
@@ -145,6 +145,5 @@ export class User extends BaseUser {
 	@JoinTable()
 	@CanReadRelation()
 	@OnlySelfCanWrite()
-	@AnyoneCanRead()
 	public termRelations: Term[] = undefined;
 }

--- a/test/spec/terms/user/user-get.spec.ts
+++ b/test/spec/terms/user/user-get.spec.ts
@@ -74,8 +74,7 @@ describe('[User] API Read', () => {
 			await http
 				.get('/api/v1/user', {
 					where: { username: user.body['username'] },
-					join: [ 'termRelations' ],
-					select: [ 'id' ]
+					join: [ 'termRelations' ]
 				})
 				.then((result) => {
 					expect(result.body).toEqual(jasmine.any(Array));

--- a/test/spec/terms/user/user-get.spec.ts
+++ b/test/spec/terms/user/user-get.spec.ts
@@ -54,6 +54,37 @@ describe('[User] API Read', () => {
 			.catch((error) => fail(JSON.stringify(error)));
 	});
 
+	it('can get one', async () => {
+		// Create base user
+		const user = await http
+			.post('/api/v1/user', {
+				fname: 'termUserGetOne',
+				lname: 'termUserGetOne',
+				username: 'termUserGetOne',
+				password: 'password123',
+				email: 'termUserGetOne@test.com',
+				termRelations: [ this.term.body ]
+			})
+			.catch((error) =>
+				fail('Could not create base user: ' + JSON.stringify(error))
+			);
+
+		// Get & check result
+		if (user) {
+			await http
+				.get('/api/v1/user', {
+					id: user.body['id']
+				})
+				.then((result) => {
+					expect(result.body).toEqual(jasmine.any(Object));
+				})
+				.catch((error) => fail('Cannot get: ' + JSON.stringify(error)));
+		}
+		else {
+			fail();
+		}
+	});
+
 	it('can read term relations', async () => {
 		// Create base user
 		const user = await http


### PR DESCRIPTION
## [1.1.1] Mar-04-2019

### Fixes
- Added CanReadRelation() on Term end of termRelations
- Removed AnyoneCanRead() from User termRelations
- Removed select query from Term relationship test
- Added get one test to Term relationship test suite