### PR TITLE
V1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # PointyApi Changelog
 
+## [1.1.2] Mar-05-2019
+
+### Fixes
+- Removed JoinColumn() from Term author
+- [Issue #144] readFilter() detypes nested arrays of objects
+
 ## [1.1.1] Mar-04-2019
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"author": "stateless-studio",
 	"license": "MIT",
 	"scripts": {

--- a/src/bodyguard/read-filter.ts
+++ b/src/bodyguard/read-filter.ts
@@ -20,7 +20,8 @@ export function readFilter(
 ): any {
 	if (obj instanceof Array) {
 		for (let i = 0; i < obj.length; i++) {
-			obj[i] = readFilter(obj[i], user, objType, userType);
+			const subObjTpye = obj[i].constructor;
+			obj[i] = readFilter(obj[i], user, subObjTpye, userType);
 		}
 	}
 	else if (obj instanceof Object) {

--- a/test/examples/terms/models/term.ts
+++ b/test/examples/terms/models/term.ts
@@ -36,9 +36,8 @@ export class Term extends BaseModel {
 	@ManyToOne((type) => User, (user) => user.terms, {
 		eager: true
 	})
-	@JoinColumn()
 	@BodyguardKey()
-	@AnyoneCanRead()
+	@CanReadRelation()
 	@OnlyAdminCanWrite()
 	@CanSearchRelation({
 		who: BodyguardOwner.Self,

--- a/test/spec/terms/user/user-get.spec.ts
+++ b/test/spec/terms/user/user-get.spec.ts
@@ -116,6 +116,12 @@ describe('[User] API Read', () => {
 						jasmine.any(Array)
 					);
 					expect(result.body[0].termRelations['length']).toBe(1);
+					expect(
+						result.body[0].termRelations[0].id
+					).toBeGreaterThanOrEqual(1);
+					expect(result.body[0].termRelations[0].title).toEqual(
+						jasmine.any(String)
+					);
 				})
 				.catch((error) => fail('Cannot get: ' + JSON.stringify(error)));
 		}


### PR DESCRIPTION
## [1.1.2] Mar-05-2019

### Fixes
- Removed JoinColumn() from Term author
- [Issue #144] readFilter() detypes nested arrays of objects
