### PR TITLE
[3.0.0] Jun-20-2019

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10.13.0"
+  - "10.15.3"
 before_script:
   - psql -c 'create database testdb;' -U postgres
   - cp local.config.travis.json local.config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # PointyApi Changelog
 
+## [3.0.0] Jun-20-2019
+
+### Breaking Changes (See migration.md)
+- [Issue #179] Swap http expect & token param
+- Removed database error handler
+- Changed `refreshToken` to `__refreshToken` in post endpoints
+- Changed `CLIENT_URL` to `ALLOW_ORIGIN`
+
+### Additions
+- Added jwtBearer::sign argument
+- Added pointy::testmode
+- Added new ipc message test
+- Added ExampleUser class
+- Added ready-check prior to starting server
+- Added BaseDb::conn
+- Moved Postgres members to BaseDB
+
+### Fixes
+- Error handling
+- Fixed a bug which mixed up `JWT_TTL` and `JWT_REFRESH_TTL`
+- runHook should log error
+- patchEndpoint should merge payload after patch hook
+- Login endpoint should check validation
+- npm update
+- Simplified login endpoint
+- Fixed default entities bug
+- Moved "server-ready" ipc from listen() to pointy::start()
+
 ## [2.0.0] Jun-06-2019
 
 ### Breaking Changes (See migration.md)

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ npm i pointyapi
 To launch in production mode, please make sure the following variables are set (environment variables/.env)
 
 - **SITE_TITLE** - Set the site title
-- **CLIENT_URL** - Set your client URL to add the client to the CORS policy
+- **ALLOW_ORIGIN** - Set your client URL to add the client to the CORS policy
 - **JWT_KEY** - Set your token key to make JWT cryptographically secure
 - **JWT_TTL** - Set your token time-to-live (seconds). Default is 15 minutes
 - **JWT_REFRESH_TTL** - Set your refresh token time-to-live (seconds). Default is 7 days.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ npm i pointyapi
 			.setEntities(
 				[
 					/* TODO: We will set our models here */
+					ExampleUser
 				]
 			)
 			.connect(ROOT_PATH)
@@ -168,7 +169,7 @@ npm i pointyapi
 	```
 3. **Create a user route**
   
-	By default, PointyAPI will use `BaseUser` as the user model. Let's create a route for this model, so that we can access this model through our API:
+	By default, PointyAPI will use `ExampleUser` as the user model. Let's create a route for this model, so that we can access this model through our API:
    - Create a folder for routes, `src/routes/`
    - Create a new router file, `src/routes/user.ts`
    - Copy & paste router code:
@@ -178,7 +179,7 @@ npm i pointyapi
 
 	import { Router } from 'express';
 	import { setModel } from 'pointyapi';
-	import { BaseUser } from 'pointyapi/models';
+	import { ExampleUser } from 'pointyapi/models';
 	import { postFilter, getFilter, patchFilter } from 'pointyapi/filters';
 	import { onlySelf } from 'pointyapi/guards';
 	import {
@@ -190,9 +191,9 @@ npm i pointyapi
 
 	const router: Router = Router();
 
-	// Set the route model to BaseUser
+	// Set the route model to ExampleUser
 	async function loader(request, response, next) {
-		if (await setModel(request, response, BaseUser)) {
+		if (await setModel(request, response, ExampleUser)) {
 			next();
 		}
 	}
@@ -211,7 +212,7 @@ npm i pointyapi
 	Open `src/index.ts` up again, and let's import our new User route.
 
 	```typescript
-	import { BaseUser } from 'pointyapi/models'; // Add import to our user model
+	import { ExampleUser } from 'pointyapi/models'; // Add import to our user model
 
 	...
 	// Routes
@@ -229,7 +230,7 @@ npm i pointyapi
 		.setEntities(
 			[
 				/* TODO: We will set our models here */
-				BaseUser // Add our BaseModel model to the database
+				ExampleUser // Add our BaseModel model to the database
 			]
 		)
 
@@ -304,14 +305,14 @@ npm i pointyapi
 
 	import { Router } from 'express';
 	import { loginEndpoint, logoutEndpoint } from 'pointyapi/endpoints';
-	import { BaseUser } from 'pointyapi/models';
+	import { ExampleUser } from 'pointyapi/models';
 	import { setModel } from 'pointyapi';
 
 	const router: Router = Router();
 
 	// Set our route model & activate auth route
 	async function loader(request, response, next) {
-		if (await setModel(request, response, BaseUser, true)) {
+		if (await setModel(request, response, ExampleUser, true)) {
 			next();
 		}
 	}
@@ -344,7 +345,7 @@ npm i pointyapi
 		.setEntities(
 			[
 				/* TODO: We will set our models here */
-				BaseUser
+				ExampleUser
 			]
 		)
 

--- a/migration.md
+++ b/migration.md
@@ -1,5 +1,11 @@
 # Migration Guide
 
+## What version do you have?
+> Choose the version you have before upgrading, and follow the guide to the bottom from there.
+- [Version 0.x.x](#version-0.x.x-->-1.x.x)
+- [Version 1.x.x](#version-1.x.x-->-2.x.x)
+- [Version 2.x.x](#version-2.x.x-->-3.x.x)
+
 ## Version 0.x.x -> 1.x.x
 
 1. Remove `response` parameter from responders and handlers
@@ -119,4 +125,15 @@
 
 4. **(Optional)** Guards will now issue a `401` only if a token is not present/valid, otherwise will issue a `403`. This may help determine if the user is authenticated/authorized on the front-end.
 
-5. HTTP Client has swapped the `bearer` and `expect` parameters. You must swap these in your code, if used
+## Version 2.x.x -> 3.x.x
+
+1. If you use the PointyAPI HTTP Client, the functions have swapped the `bearer` and `expect` parameters. You must swap these in your code.
+2. If your code uses a custom database error handler, this should be removed and the pointyapi error handler used instead.
+3. `CLIENT_URL` is no longer used for CORS policy. Now you should use `ALLOW_ORIGINS`. **However, `CLIENT_URL` is still used for links, etc - so don't remove it**.
+	Example:
+	
+	`/.env`
+	```
+	CLIENT_URL=http://example.com/
+	ALLOW_ORIGINS=http://example.com/, http://cool-example.com/
+	```

--- a/migration.md
+++ b/migration.md
@@ -118,3 +118,5 @@
    **NOTE** If you are already in production and decide to migrate to UUID, you must make sure to update relations etc
 
 4. **(Optional)** Guards will now issue a `401` only if a token is not present/valid, otherwise will issue a `403`. This may help determine if the user is authenticated/authorized on the front-end.
+
+5. HTTP Client has swapped the `bearer` and `expect` parameters. You must swap these in your code, if used

--- a/migration.md
+++ b/migration.md
@@ -31,7 +31,7 @@
 	```typescript
 	// Set model
 	router.use((request, response, next) => {
-		if (await setModel(request, response, BaseUser)) {
+		if (await setModel(request, response, ExampleUser)) {
 			// Note that this next() call is now in an if-statement around the setModel()
 			next();
 		}
@@ -51,7 +51,7 @@
 	// Set model
 	router.use((request, response, next) => {
 		//                                               vvv add this for auth routes
-		if (await setModel(request, response, BaseUser, true)) {
+		if (await setModel(request, response, ExampleUser, true)) {
 			// Note that this next() call is now in an if-statement around the setModel()
 			next();
 		}

--- a/migration.md
+++ b/migration.md
@@ -110,9 +110,9 @@
 1. Auth tokens are now completely stateless. Remove the `token` field from your User entity.
 2. Login now issues a refresh token.
    1. Make a POST endpoint in your auth router:
-		`router.post('/refresh', refreshTokenEndpoint);` 
-   2. Update your front-end auth service to save the `refreshToken` and `refreshExpiration` from the `loginEndpoint`
-   3. Set a timeout to call the `refreshTokenEndpoint` route when the access token expires. `refreshTokenEndpoint` will return an updated user object, including a new access token & expiration time.
+		`router.post('/refresh', loader, refreshTokenEndpoint);` 
+   2. Update your front-end auth refreshTokenservice to save the `refreshToken` and `refreshExpiration` from the `loginEndpoint`
+   3. Set a timeout to call the `refreshTokenEndpoint` route when the access token expires. Setup the body like this: `{ __refreshToken: myRefreshToken }`.  This will return an updated user object, including a new access token & expiration time.
 3. **(Optional)** PointyAPI now supports `UUID`. Follow the steps in the Readme to enable UUID (strongly recommended for production).
 
    **NOTE** If you are already in production and decide to migrate to UUID, you must make sure to update relations etc

--- a/orm-cli.js
+++ b/orm-cli.js
@@ -8,6 +8,6 @@ module.exports = {
 	user: dbSettings.user,
 	password: dbSettings.password,
 	database: dbSettings.database,
-	entities: [ 'lib/src/models/base-user.ts' ],
+	entities: [],
 	uuidExtension: 'pgcrypto'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -677,9 +677,9 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"coveralls": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.3.tgz",
-			"integrity": "sha512-viNfeGlda2zJr8Gj1zqXpDMRjw9uM54p7wzZdvLRyOgnAfCe974Dq4veZkjJdxQXbmdppu6flEajFYseHYaUhg==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.4.tgz",
+			"integrity": "sha512-eyqUWA/7RT0JagiL0tThVhjbIjoiEUyWCjtUJoOPcWoeofP5WK/jb2OJYoBFrR6DvplR+AxOyuBqk4JHkk5ykA==",
 			"dev": true,
 			"requires": {
 				"growl": "~> 1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
 			}
@@ -23,14 +24,6 @@
 				"lodash": "^4.17.11",
 				"source-map": "^0.5.0",
 				"trim-right": "^1.0.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-function-name": {
@@ -66,6 +59,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
 			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -116,9 +110,9 @@
 					}
 				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
@@ -195,9 +189,9 @@
 			}
 		},
 		"@types/caseless": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
-			"integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+			"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
 		},
 		"@types/connect": {
 			"version": "3.4.32",
@@ -218,9 +212,9 @@
 			}
 		},
 		"@types/express-serve-static-core": {
-			"version": "4.16.6",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.6.tgz",
-			"integrity": "sha512-8wr3CA/EMybyb6/V8qvTRKiNkPmgUA26uA9XWD6hlA0yFDuqi4r2L0C2B0U2HAYltJamoYJszlkaWM31vrKsHg==",
+			"version": "4.16.7",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+			"integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
 			"requires": {
 				"@types/node": "*",
 				"@types/range-parser": "*"
@@ -237,7 +231,8 @@
 		"@types/jasmine": {
 			"version": "2.8.16",
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.8.16.tgz",
-			"integrity": "sha512-056oRlBBp7MDzr+HoU5su099s/s7wjZ3KcHxLfv+Byqb9MwdLUvsfLgw1VS97hsh3ddxSPyQu+olHMnoVTUY6g=="
+			"integrity": "sha512-056oRlBBp7MDzr+HoU5su099s/s7wjZ3KcHxLfv+Byqb9MwdLUvsfLgw1VS97hsh3ddxSPyQu+olHMnoVTUY6g==",
+			"dev": true
 		},
 		"@types/jsonwebtoken": {
 			"version": "7.2.8",
@@ -253,9 +248,9 @@
 			"integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
 		},
 		"@types/node": {
-			"version": "10.14.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
-			"integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw=="
+			"version": "10.14.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
+			"integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg=="
 		},
 		"@types/range-parser": {
 			"version": "1.2.3",
@@ -287,12 +282,6 @@
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
 			"integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
 		},
-		"abbrev": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-			"dev": true
-		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -300,40 +289,18 @@
 			"requires": {
 				"mime-types": "~2.1.24",
 				"negotiator": "0.6.2"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.40.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
-				},
-				"mime-types": {
-					"version": "2.1.24",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-					"requires": {
-						"mime-db": "1.40.0"
-					}
-				}
 			}
 		},
 		"ajv": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-			"integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
 			}
-		},
-		"amdefine": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true,
-			"optional": true
 		},
 		"ansi-regex": {
 			"version": "4.1.0",
@@ -410,12 +377,6 @@
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
-		"async": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-			"dev": true
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -474,13 +435,6 @@
 				"qs": "6.7.0",
 				"raw-body": "2.4.0",
 				"type-is": "~1.6.17"
-			},
-			"dependencies": {
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-				}
 			}
 		},
 		"brace-expansion": {
@@ -525,7 +479,8 @@
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"bytes": {
 			"version": "3.1.0",
@@ -616,9 +571,9 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -626,7 +581,8 @@
 		"commander": {
 			"version": "2.20.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -712,12 +668,14 @@
 			}
 		},
 		"cross-spawn": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-			"dev": true,
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"requires": {
-				"lru-cache": "^4.0.1",
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
 		},
@@ -741,12 +699,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-		},
-		"deep-is": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
 		},
 		"default-require-extensions": {
 			"version": "2.0.0",
@@ -781,6 +733,7 @@
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
 			"integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+			"dev": true,
 			"requires": {
 				"esutils": "^1.1.6",
 				"isarray": "0.0.1"
@@ -789,7 +742,8 @@
 				"esutils": {
 					"version": "1.1.6",
 					"resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-					"integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U="
+					"integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+					"dev": true
 				}
 			}
 		},
@@ -863,42 +817,16 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
-		"escodegen": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-			"dev": true,
-			"requires": {
-				"esprima": "^2.7.1",
-				"estraverse": "^1.9.1",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.2.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-					"dev": true
-				}
-			}
-		},
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
-		"estraverse": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-			"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-			"dev": true
-		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -917,20 +845,6 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				}
 			}
 		},
 		"express": {
@@ -968,13 +882,6 @@
 				"type-is": "~1.6.18",
 				"utils-merge": "1.0.1",
 				"vary": "~1.1.2"
-			},
-			"dependencies": {
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-				}
 			}
 		},
 		"extend": {
@@ -996,12 +903,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-		},
-		"fast-levenshtein": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
 		},
 		"figlet": {
 			"version": "1.2.3",
@@ -1049,6 +950,18 @@
 			"requires": {
 				"cross-spawn": "^4",
 				"signal-exit": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				}
 			}
 		},
 		"forever-agent": {
@@ -1103,9 +1016,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1202,9 +1115,9 @@
 			}
 		},
 		"highlight.js": {
-			"version": "9.15.6",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
-			"integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ=="
+			"version": "9.15.8",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.8.tgz",
+			"integrity": "sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA=="
 		},
 		"hosted-git-info": {
 			"version": "2.7.1",
@@ -1313,70 +1226,6 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
-		"istanbul": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-			"dev": true,
-			"requires": {
-				"abbrev": "1.0.x",
-				"async": "1.x",
-				"escodegen": "1.8.x",
-				"esprima": "2.7.x",
-				"glob": "^5.0.15",
-				"handlebars": "^4.0.1",
-				"js-yaml": "3.x",
-				"mkdirp": "0.5.x",
-				"nopt": "3.x",
-				"once": "1.x",
-				"resolve": "1.1.x",
-				"supports-color": "^3.1.0",
-				"which": "^1.1.1",
-				"wordwrap": "^1.0.0"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-					"dev": true
-				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
-					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.1.7",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
-		},
 		"istanbul-lib-coverage": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
@@ -1460,9 +1309,9 @@
 					}
 				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				},
 				"source-map": {
@@ -1486,6 +1335,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.4.0.tgz",
 			"integrity": "sha512-sR9b4n+fnBFDEd7VS2el2DeHgKcPiMVn44rtKFumq9q7P/t8WrxsVIZPob4UDdgcDNCwyDqwxCt4k9TDRmjPoQ==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.3",
 				"jasmine-core": "~3.4.0"
@@ -1494,12 +1344,14 @@
 		"jasmine-core": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.4.0.tgz",
-			"integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg=="
+			"integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg==",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -1560,9 +1412,9 @@
 			},
 			"dependencies": {
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
@@ -1614,16 +1466,6 @@
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
 			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
 			"dev": true
-		},
-		"levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
-			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
-			}
 		},
 		"load-json-file": {
 			"version": "4.0.0",
@@ -1707,9 +1549,9 @@
 			"dev": true
 		},
 		"lolex": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.0.1.tgz",
-			"integrity": "sha512-UHuOBZ5jjsKuzbB/gRNNW8Vg8f00Emgskdq2kvZxgBJCS0aqquAuXai/SkWORlKeZEiNQWZjFZOqIUcH9LqKCw=="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+			"integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw=="
 		},
 		"lru-cache": {
 			"version": "4.1.5",
@@ -1793,16 +1635,16 @@
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mime-db": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
 		},
 		"mime-types": {
-			"version": "2.1.22",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+			"version": "2.1.24",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
 			"requires": {
-				"mime-db": "~1.38.0"
+				"mime-db": "1.40.0"
 			}
 		},
 		"mimic-fn": {
@@ -1857,9 +1699,9 @@
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
 		"neo-async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
 			"dev": true
 		},
 		"nested-error-stacks": {
@@ -1874,22 +1716,17 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"nise": {
-			"version": "1.4.10",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
-			"integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+			"integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
 			"requires": {
 				"@sinonjs/formatio": "^3.1.0",
 				"@sinonjs/text-encoding": "^0.7.1",
 				"just-extend": "^4.0.2",
-				"lolex": "^2.3.2",
+				"lolex": "^4.1.0",
 				"path-to-regexp": "^1.7.0"
 			},
 			"dependencies": {
-				"lolex": {
-					"version": "2.7.5",
-					"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-					"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q=="
-				},
 				"path-to-regexp": {
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
@@ -1898,15 +1735,6 @@
 						"isarray": "0.0.1"
 					}
 				}
-			}
-		},
-		"nopt": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"dev": true,
-			"requires": {
-				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -1996,28 +1824,6 @@
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
-			},
-			"dependencies": {
-				"wordwrap": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-					"dev": true
-				}
-			}
-		},
-		"optionator": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"dev": true,
-			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
 			}
 		},
 		"os-homedir": {
@@ -2132,7 +1938,8 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -2260,12 +2067,6 @@
 				"xtend": "^4.0.0"
 			}
 		},
-		"prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
-		},
 		"proxy-addr": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -2282,9 +2083,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+			"version": "1.1.32",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+			"integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
 		},
 		"pump": {
 			"version": "3.0.0",
@@ -2301,9 +2102,9 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
 		},
 		"range-parser": {
 			"version": "1.2.1",
@@ -2381,6 +2182,13 @@
 				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"qs": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+				}
 			}
 		},
 		"require-directory": {
@@ -2394,9 +2202,10 @@
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
 		},
 		"resolve": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+			"integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -2432,9 +2241,9 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 		},
 		"send": {
 			"version": "0.17.1",
@@ -2517,14 +2326,10 @@
 			}
 		},
 		"source-map": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-			"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"amdefine": ">=0.0.4"
-			}
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.5.12",
@@ -2752,14 +2557,15 @@
 			}
 		},
 		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
 		},
 		"tslint": {
 			"version": "5.17.0",
 			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.17.0.tgz",
 			"integrity": "sha512-pflx87WfVoYepTet3xLfDOLDm9Jqi61UXIKePOuca0qoAZyrGWonDG9VTbji58Fy+8gciUn8Bt7y69+KEVjc/w==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
@@ -2780,6 +2586,7 @@
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz",
 			"integrity": "sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==",
+			"dev": true,
 			"requires": {
 				"doctrine": "0.7.2",
 				"tslib": "1.9.0",
@@ -2789,12 +2596,14 @@
 				"tslib": {
 					"version": "1.9.0",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-					"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+					"integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+					"dev": true
 				},
 				"tsutils": {
-					"version": "3.8.0",
-					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.8.0.tgz",
-					"integrity": "sha512-XQdPhgcoTbCD8baXC38PQ0vpTZ8T3YrE+vR66YIj/xvDt1//8iAhafpIT/4DmvzzC1QFapEImERu48Pa01dIUA==",
+					"version": "3.14.0",
+					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
+					"integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
+					"dev": true,
 					"requires": {
 						"tslib": "^1.8.1"
 					}
@@ -2805,6 +2614,7 @@
 			"version": "2.29.0",
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
 			}
@@ -2822,15 +2632,6 @@
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
-		"type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
-			"requires": {
-				"prelude-ls": "~1.1.2"
-			}
-		},
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -2843,21 +2644,6 @@
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.40.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
-				},
-				"mime-types": {
-					"version": "2.1.24",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-					"requires": {
-						"mime-db": "1.40.0"
-					}
-				}
 			}
 		},
 		"typeorm": {
@@ -2890,21 +2676,22 @@
 					}
 				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
 		"typescript": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
-			"integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw=="
+			"integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.5.11",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
-			"integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -2988,9 +2775,9 @@
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
 			"dev": true
 		},
 		"wrap-ansi": {
@@ -3115,9 +2902,9 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
-			"integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
+			"version": "13.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1995,9 +1995,9 @@
 			}
 		},
 		"pg-connection-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.0.0.tgz",
-			"integrity": "sha1-Pu/lmX4G2Ugh5NUC5CtqHHP434I="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.1.0.tgz",
+			"integrity": "sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg=="
 		},
 		"pg-int8": {
 			"version": "1.0.1",
@@ -2683,9 +2683,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
-			"integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+			"integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	"types": "./index.d.ts",
 	"devDependencies": {
 		"@istanbuljs/nyc-config-typescript": "^0.1.3",
-		"coveralls": "^3.0.3",
+		"coveralls": "^3.0.4",
 		"istanbul": "^0.4.5",
 		"nyc": "^14.1.1",
 		"source-map-support": "^0.5.12",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 		"@types/atob": "^2.1.2",
 		"@types/btoa": "^1.2.3",
 		"@types/express": "^4.17.0",
-		"@types/jasmine": "^2.8.16",
 		"@types/jsonwebtoken": "^7.2.8",
 		"@types/node": "^10.14.8",
 		"@types/request": "^2.48.1",
@@ -34,7 +33,6 @@
 		"btoa": "^1.2.1",
 		"class-validator": "^0.9.1",
 		"express": "^4.17.1",
-		"jasmine": "^3.4.0",
 		"jsonwebtoken": "^8.5.1",
 		"mock-req-res": "^1.1.1",
 		"pg": "^7.11.0",
@@ -42,21 +40,22 @@
 		"reflect-metadata": "^0.1.13",
 		"request": "^2.88.0",
 		"sinon": "^7.3.2",
-		"tslint": "^5.17.0",
-		"tslint-eslint-rules": "^5.4.0",
 		"typeorm": "^0.2.18",
-		"typescript": "^3.5.1",
 		"validator": "^10.11.0"
 	},
 	"main": "./index.js",
 	"types": "./index.d.ts",
 	"devDependencies": {
+		"@types/jasmine": "^2.8.16",
 		"@istanbuljs/nyc-config-typescript": "^0.1.3",
 		"coveralls": "^3.0.4",
-		"istanbul": "^0.4.5",
 		"nyc": "^14.1.1",
 		"source-map-support": "^0.5.12",
-		"ts-node": "^7.0.1"
+		"ts-node": "^7.0.1",
+		"jasmine": "^3.4.0",
+		"tslint": "^5.17.0",
+		"tslint-eslint-rules": "^5.4.0",
+		"typescript": "^3.5.1"
 	},
 	"description": "*\"Stop writing endpoints\"*",
 	"directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pointyapi",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"author": "stateless-studio",
 	"license": "MIT",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"jsonwebtoken": "^8.5.1",
 		"mock-req-res": "^1.1.1",
 		"pg": "^7.11.0",
-		"pg-connection-string": "^2.0.0",
+		"pg-connection-string": "^2.1.0",
 		"reflect-metadata": "^0.1.13",
 		"request": "^2.88.0",
 		"sinon": "^7.3.2",
@@ -46,16 +46,16 @@
 	"main": "./index.js",
 	"types": "./index.d.ts",
 	"devDependencies": {
-		"@types/jasmine": "^2.8.16",
 		"@istanbuljs/nyc-config-typescript": "^0.1.3",
+		"@types/jasmine": "^2.8.16",
 		"coveralls": "^3.0.4",
+		"jasmine": "^3.4.0",
 		"nyc": "^14.1.1",
 		"source-map-support": "^0.5.12",
 		"ts-node": "^7.0.1",
-		"jasmine": "^3.4.0",
 		"tslint": "^5.17.0",
 		"tslint-eslint-rules": "^5.4.0",
-		"typescript": "^3.5.1"
+		"typescript": "^3.5.2"
 	},
 	"description": "*\"Stop writing endpoints\"*",
 	"directories": {

--- a/src/bodyguard.ts
+++ b/src/bodyguard.ts
@@ -55,7 +55,7 @@
  * You will need to add the appropriate bodyguards on your model:
  *
  * ```typescript
- * import { BaseUser } from 'pointyapi/models';
+ * import { ExampleUser } from 'pointyapi/models';
  * import {
  * 	CanRead,
  * 	AnyoneCanRead,
@@ -69,7 +69,7 @@
  * } from 'pointyapi/bodyguards';
  * import { UserRole, UserStatus, BodyguardOwner } from 'pointyapi/enums';
  *
- * export class User extends BaseUser() {
+ * export class User extends BaseUser {
  *		// ID
  *		@BodyguardKey() // Determine who can read/write from here
  *		@AnyoneCanRead()

--- a/src/database.ts
+++ b/src/database.ts
@@ -15,13 +15,13 @@
  * this in your `pointy.before` function.**
  * ```typescript
  * import { pointy } from 'pointyapi';
- * import { BaseUser } from 'pointyapi/models';
+ * import { ExampleUser } from 'pointyapi/models';
  * const ROOT_PATH = require('app-root-path');
  *
  * // Database
  * pointy.before = async (app) => {
  * 		await pointy.db
- * 			.setEntities([ BaseUser ])
+ * 			.setEntities([ ExampleUser ])
  * 			.connect(ROOT_PATH)
  * 			.catch((error) => pointy.error(error));
  * });

--- a/src/database/base-db.ts
+++ b/src/database/base-db.ts
@@ -1,5 +1,5 @@
 import { Connection } from 'typeorm';
-import { BaseUser } from '../models';
+import { ExampleUser } from '../models/example-user';
 
 /**
  * Base Database class
@@ -12,7 +12,7 @@ export class BaseDb {
 	public errorHandler: Function = (error) => console.error(error);
 
 	// Database entities
-	public entities = [ BaseUser ];
+	public entities: any[] = [ ExampleUser ];
 
 	// Connection name.  Default is "default"
 	public connectionName = 'default';

--- a/src/database/base-db.ts
+++ b/src/database/base-db.ts
@@ -1,3 +1,5 @@
+import { Connection } from 'typeorm';
+
 /**
  * Base Database class
  */
@@ -8,6 +10,15 @@ export class BaseDb {
 	// Database error function
 	public errorHandler: Function = (error) => console.error(error);
 
+	// Database entities
+	public entities = [];
+
+	// Connection name.  Default is "default"
+	public connectionName = 'default';
+
+	// Auto-sync (Empties database on restart, not for production!)
+	public shouldSync = false;
+
 	/**
 	 * Constructor
 	 */
@@ -17,7 +28,9 @@ export class BaseDb {
 	 * Set ORM entities
 	 * @param entities Array of entities
 	 */
-	public setEntities(entities: any[]): BaseDb {
+	public setEntities(entities: any[]) {
+		this.entities = entities;
+
 		return this;
 	}
 

--- a/src/database/base-db.ts
+++ b/src/database/base-db.ts
@@ -8,9 +8,6 @@ export class BaseDb {
 	// Database logging function
 	public logger: Function = (message, body?) => console.log(message, body);
 
-	// Database error function
-	public errorHandler: Function = (error) => console.error(error);
-
 	// Database entities
 	public entities: any[] = [ ExampleUser ];
 

--- a/src/database/base-db.ts
+++ b/src/database/base-db.ts
@@ -1,4 +1,4 @@
-import { Connection } from 'typeorm';
+import { BaseUser } from '../models';
 
 /**
  * Base Database class
@@ -11,7 +11,7 @@ export class BaseDb {
 	public errorHandler: Function = (error) => console.error(error);
 
 	// Database entities
-	public entities = [];
+	public entities = [ BaseUser ];
 
 	// Connection name.  Default is "default"
 	public connectionName = 'default';

--- a/src/database/base-db.ts
+++ b/src/database/base-db.ts
@@ -1,3 +1,4 @@
+import { Connection } from 'typeorm';
 import { BaseUser } from '../models';
 
 /**
@@ -18,6 +19,9 @@ export class BaseDb {
 
 	// Auto-sync (Empties database on restart, not for production!)
 	public shouldSync = false;
+
+	// Connection
+	public conn: Connection;
 
 	/**
 	 * Constructor

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -2,7 +2,6 @@ import * as PostgressConnectionStringParser from 'pg-connection-string';
 import { createConnection, ConnectionOptions } from 'typeorm';
 import * as path from 'path';
 
-import { BaseUser } from '../models/base-user';
 import { BaseDb } from './base-db';
 
 /**
@@ -53,7 +52,7 @@ export class PointyPostgres extends BaseDb {
 		}
 
 		// Create connection
-		await createConnection(<ConnectionOptions>{
+		this.conn = await createConnection(<ConnectionOptions>{
 			name: this.connectionName,
 			type: process.env.TYPEORM_DRIVER_TYPE || pgOptions.type,
 			driver: process.env.TYPEORM_DRIVER_TYPE || pgOptions.type,
@@ -68,5 +67,7 @@ export class PointyPostgres extends BaseDb {
 				? pgOptions.uuidExtension
 				: 'pgcrypto'
 		}).catch((error) => this.errorHandler(error));
+
+		return this.conn;
 	}
 }

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -1,5 +1,5 @@
 import * as PostgressConnectionStringParser from 'pg-connection-string';
-import { createConnection, ConnectionOptions } from 'typeorm';
+import { createConnection, ConnectionOptions, Connection } from 'typeorm';
 import * as path from 'path';
 
 import { BaseDb } from './base-db';
@@ -14,7 +14,7 @@ export class PointyPostgres extends BaseDb {
 	 * 	a string to load from file, or pass the object directly).  Database
 	 * 	will rely on `process.env.DATABASE_URL` if this is not set.
 	 */
-	public async connect(options?: string | Object): Promise<any> {
+	public async connect(options?: string | Object): Promise<Connection> {
 		let pgOptions: any;
 
 		if (process.env.DATABASE_URL) {

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -14,60 +14,68 @@ export class PointyPostgres extends BaseDb {
 	 * 	a string to load from file, or pass the object directly).  Database
 	 * 	will rely on `process.env.DATABASE_URL` if this is not set.
 	 */
-	public async connect(options?: string | Object): Promise<Connection> {
-		let pgOptions: any;
+	public connect(options?: string | Object): Promise<Connection> {
+		return new Promise(async (accept, reject) => {
+			let pgOptions: any;
 
-		if (process.env.DATABASE_URL) {
-			// Live
-			pgOptions = PostgressConnectionStringParser.parse(
-				process.env.DATABASE_URL
-			);
-			pgOptions.type = 'postgres';
+			if (process.env.DATABASE_URL) {
+				// Live
+				pgOptions = PostgressConnectionStringParser.parse(
+					process.env.DATABASE_URL
+				);
+				pgOptions.type = 'postgres';
 
-			this.logger('Using production database');
-			this.logger(
-				'Using database driver',
-				process.env.TYPEORM_DRIVER_TYPE || pgOptions.type
-			);
-		}
-		else {
-			// Local
-			if (typeof options === 'string') {
-				pgOptions = require(path.join(
-					options.toString(),
-					'local.config.json'
-				));
+				this.logger('Using production database');
+				this.logger(
+					'Using database driver',
+					process.env.TYPEORM_DRIVER_TYPE || pgOptions.type
+				);
 			}
 			else {
-				pgOptions = options;
+				// Local
+				if (typeof options === 'string') {
+					pgOptions = require(path.join(
+						options.toString(),
+						'local.config.json'
+					));
+				}
+				else {
+					pgOptions = options;
+				}
+
+				this.logger('Using development database');
+				this.logger(
+					'Using database driver',
+					process.env.TYPEORM_DRIVER_TYPE || pgOptions.type
+				);
+
+				this.shouldSync = true;
 			}
 
-			this.logger('Using development database');
-			this.logger(
-				'Using database driver',
-				process.env.TYPEORM_DRIVER_TYPE || pgOptions.type
-			);
+			// Create connection
+			const conn = await createConnection(<ConnectionOptions>{
+				name: this.connectionName,
+				type: process.env.TYPEORM_DRIVER_TYPE || pgOptions.type,
+				driver: process.env.TYPEORM_DRIVER_TYPE || pgOptions.type,
+				host: pgOptions.host,
+				port: pgOptions.port,
+				username: pgOptions.user,
+				password: pgOptions.password,
+				database: pgOptions.database,
+				entities: this.entities,
+				synchronize: this.shouldSync,
+				uuidExtension: pgOptions.uuidExtension
+					? pgOptions.uuidExtension
+					: 'pgcrypto'
+			}).catch((error) => {
+				reject(error);
+				return false;
+			});
 
-			this.shouldSync = true;
-		}
-
-		// Create connection
-		this.conn = await createConnection(<ConnectionOptions>{
-			name: this.connectionName,
-			type: process.env.TYPEORM_DRIVER_TYPE || pgOptions.type,
-			driver: process.env.TYPEORM_DRIVER_TYPE || pgOptions.type,
-			host: pgOptions.host,
-			port: pgOptions.port,
-			username: pgOptions.user,
-			password: pgOptions.password,
-			database: pgOptions.database,
-			entities: this.entities,
-			synchronize: this.shouldSync,
-			uuidExtension: pgOptions.uuidExtension
-				? pgOptions.uuidExtension
-				: 'pgcrypto'
-		}).catch((error) => this.errorHandler(error));
-
-		return this.conn;
+			if (conn && conn instanceof Connection) {
+				this.conn = conn;
+				accept(this.conn);
+			}
+		});
 	}
 }

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -9,34 +9,6 @@ import { BaseDb } from './base-db';
  * Postgres Database Handler
  */
 export class PointyPostgres extends BaseDb {
-	// Connection name.  Default is "default"
-	public connectionName = 'default';
-
-	// Auto-sync (Empties database on restart, not for production!)
-	public shouldSync = false;
-
-	// Database entities
-	public entities: any[];
-
-	/**
-	 * Constructor
-	 */
-	constructor() {
-		super();
-
-		this.entities = [ BaseUser ];
-	}
-
-	/**
-	 * Set ORM entities
-	 * @param entities Array of entities
-	 */
-	public setEntities(entities: any[]) {
-		this.entities = entities;
-
-		return this;
-	}
-
 	/**
 	 * Connect to the database
 	 * @param options Database credentials (pass

--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -20,7 +20,7 @@
  *
  * ```typescript
  * import { setModel } from 'pointyapi/set-model';
- * import { BaseUser } from 'pointyapi/models';
+ * import { ExampleUser } from 'pointyapi/models';
  *
  * // Guards
  * import { onlySelf } from 'pointyapi/guards';
@@ -41,7 +41,7 @@
  *
  * // Set model
  * async function loader(request, response, next) {
- * 		if (await setModel(request, BaseUser)) {
+ * 		if (await setModel(request, ExampleUser)) {
  * 			next();
  * 		}
  * }

--- a/src/endpoints/login-endpoint.ts
+++ b/src/endpoints/login-endpoint.ts
@@ -14,6 +14,17 @@ export async function loginEndpoint(
 	request: Request,
 	response: Response
 ): Promise<void> {
+	// Check input
+	if (!('__user' in request.body)) {
+		response.validationResponder('__user is required');
+		return;
+	}
+
+	if (!('password' in request.body)) {
+		response.validationResponder('password is required');
+		return;
+	}
+
 	// Run model hook
 	if (!await runHook('login', request.body, request, response)) {
 		return;

--- a/src/endpoints/login-endpoint.ts
+++ b/src/endpoints/login-endpoint.ts
@@ -27,19 +27,18 @@ export async function loginEndpoint(
 	}
 
 	// Create where query
-	let where = '';
+	const where = [];
 
 	for (const field of fields) {
-		where += `user.${field}=:name OR `;
+		const pair = {};
+		pair[field] = request.body.__user;
+		where.push(pair);
 	}
-	where = where.replace(/ OR +$/, '');
 
-	// Load users
 	const foundUsers = await request.repository
-		.createQueryBuilder('user')
-		.where(where)
-		.setParameters({ name: request.body.__user })
-		.getMany()
+		.find({
+			where: where
+		})
 		.catch((error) => response.error(error));
 
 	// Check users

--- a/src/endpoints/patch-endpoint.ts
+++ b/src/endpoints/patch-endpoint.ts
@@ -13,13 +13,13 @@ export async function patchEndpoint(
 	request: Request,
 	response: Response
 ): Promise<void> {
-	// Merge payload
-	request.body = Object.assign(request.payload, request.body);
-
 	// Run model hook
 	if (!await runHook('patch', request.body, request, response)) {
 		return;
 	}
+
+	// Merge payload
+	request.body = Object.assign(request.payload, request.body);
 
 	// Pass null in place of empty strings
 	for (const key in request.payload) {

--- a/src/endpoints/refresh-token-endpoint.ts
+++ b/src/endpoints/refresh-token-endpoint.ts
@@ -15,9 +15,9 @@ export async function refreshTokenEndpoint(
 	response: Response
 ): Promise<void> {
 	// Check request body
-	if ('refreshToken' in request.body) {
+	if ('__refreshToken' in request.body) {
 		// Check refresh token
-		const token = jwtBearer.dryVerify(request.body.refreshToken);
+		const token = jwtBearer.dryVerify(request.body.__refreshToken);
 
 		if (token && 'isRefresh' in token && token.isRefresh) {
 			// Load user

--- a/src/http/http-client.ts
+++ b/src/http/http-client.ts
@@ -26,15 +26,15 @@ export class HttpClient {
 	 * Send a POST http request to the server
 	 * @param path Path to send to (e.g. /users)
 	 * @param data Data to send as query
-	 * @param expect Array of status codes to expect
 	 * @param bearer Bearer token to send
+	 * @param expect Array of status codes to expect
 	 * @return Returns a promise of HttpClientResponse
 	 */
 	public post(
 		path: string,
 		data: object,
-		expect: number[] = [ 200, 201, 202, 204 ],
-		bearer: boolean | string = false
+		bearer: boolean | string = false,
+		expect: number[] = [ 200, 201, 202, 204 ]
 	): Promise<HttpClientResponse> {
 		const options = {
 			method: 'POST',
@@ -71,15 +71,15 @@ export class HttpClient {
 	 * Send a GET http request to the server
 	 * @param path Path to send to (e.g. /users)
 	 * @param data Data to send as query
-	 * @param expect Array of status codes to expect
 	 * @param bearer Bearer token to send
+	 * @param expect Array of status codes to expect
 	 * @return Returns a promise of HttpClientResponse
 	 */
 	public get(
 		path: string,
 		data: boolean | Object = false,
-		expect: number[] = [ 200, 202 ],
-		bearer: boolean | string = false
+		bearer: boolean | string = false,
+		expect: number[] = [ 200, 202 ]
 	): Promise<HttpClientResponse> {
 		return new Promise<HttpClientResponse>((accept, reject) => {
 			const options = {
@@ -116,15 +116,15 @@ export class HttpClient {
 	 * Send a PATCH http request to the server
 	 * @param path Path to send to (e.g. /users)
 	 * @param data Data to send as query
-	 * @param expect Array of status codes to expect
 	 * @param bearer Bearer token to send
+	 * @param expect Array of status codes to expect
 	 * @return Returns a promise of HttpClientResponse
 	 */
 	public patch(
 		path: string,
 		data: object,
-		expect: number[] = [ 200, 201, 202, 204 ],
-		bearer: boolean | string = false
+		bearer: boolean | string = false,
+		expect: number[] = [ 200, 201, 202, 204 ]
 	): Promise<HttpClientResponse> {
 		const options = {
 			method: 'PATCH',
@@ -161,14 +161,14 @@ export class HttpClient {
 	 * Send a DELETE http request to the server
 	 * @param path Path to send to (e.g. /users)
 	 * @param data Data to send as query
-	 * @param expect Array of status codes to expect
 	 * @param bearer Bearer token to send
+	 * @param expect Array of status codes to expect
 	 * @return Returns a promise of HttpClientResponse
 	 */
 	public delete(
 		path: string,
-		expect: number[] = [ 200, 202, 204 ],
-		bearer: boolean | string = false
+		bearer: boolean | string = false,
+		expect: number[] = [ 200, 202, 204 ]
 	): Promise<HttpClientResponse> {
 		return new Promise<HttpClientResponse>((accept, reject) => {
 			const options = {

--- a/src/jwt-bearer.ts
+++ b/src/jwt-bearer.ts
@@ -62,9 +62,18 @@ export class JwtBearer {
 	 * @param user User to sign the JWT for
 	 * @return Returns the signed, base64-encoded token
 	 */
-	public sign(user: BaseUser, isRefresh: boolean = false): string {
+	public sign(
+		user: BaseUser,
+		isRefresh: boolean = false,
+		data: Object = {}
+	): string {
+		const payload = Object.assign(data, {
+			id: user.id,
+			isRefresh: isRefresh
+		});
+
 		return btoa(
-			JWT.sign({ id: user.id, isRefresh: isRefresh }, this.key, {
+			JWT.sign(payload, this.key, {
 				expiresIn: parseInt(
 					isRefresh
 						? process.env.JWT_TTL

--- a/src/jwt-bearer.ts
+++ b/src/jwt-bearer.ts
@@ -76,8 +76,8 @@ export class JwtBearer {
 			JWT.sign(payload, this.key, {
 				expiresIn: parseInt(
 					isRefresh
-						? process.env.JWT_TTL
-						: process.env.JWT_REFRESH_TTL,
+						? process.env.JWT_REFRESH_TTL
+						: process.env.JWT_TTL,
 					10
 				)
 			})

--- a/src/jwt-bearer.ts
+++ b/src/jwt-bearer.ts
@@ -50,7 +50,7 @@ export class JwtBearer {
 		return (
 			Date.now() +
 			parseInt(
-				isRefresh ? process.env.JWT_TTL : process.env.JWT_REFRESH_TTL,
+				isRefresh ? process.env.REFRESH_TTL : process.env.JWT_TTL,
 				10
 			) *
 				1000

--- a/src/jwt-bearer.ts
+++ b/src/jwt-bearer.ts
@@ -50,7 +50,7 @@ export class JwtBearer {
 		return (
 			Date.now() +
 			parseInt(
-				isRefresh ? process.env.REFRESH_TTL : process.env.JWT_TTL,
+				isRefresh ? process.env.JWT_REFRESH_TTL : process.env.JWT_TTL,
 				10
 			) *
 				1000

--- a/src/middleware/basic-cors.ts
+++ b/src/middleware/basic-cors.ts
@@ -14,11 +14,17 @@ export function basicCors(
 	// Set Access-Control-Allow-Origin
 	let origin = '*';
 
-	if ('CLIENT_URL' in process.env && process.env.CLIENT_URL) {
-		if (process.env.CLIENT_URL.includes(', ')) {
+	// Backwards compatability
+	// TODO: Remove in v3.0.0
+	if (!('ALLOW_ORIGIN' in process.env) && 'CLIENT_URL' in process.env) {
+		process.env.ALLOW_ORIGIN = process.env.CLIENT_URL;
+	}
+
+	if ('ALLOW_ORIGIN' in process.env && process.env.ALLOW_ORIGIN) {
+		if (process.env.ALLOW_ORIGIN.includes(', ')) {
 			// Array of Client URLs
 			const host = request.header('host').toLowerCase();
-			const clientUrls = process.env.CLIENT_URL.split(', ');
+			const clientUrls = process.env.ALLOW_ORIGIN.split(', ');
 
 			if (clientUrls.includes(host)) {
 				origin = host;
@@ -27,9 +33,9 @@ export function basicCors(
 				origin = clientUrls[0];
 			}
 		}
-		else if (typeof process.env.CLIENT_URL === 'string') {
+		else if (typeof process.env.ALLOW_ORIGIN === 'string') {
 			// Single Client Url
-			origin = process.env.CLIENT_URL;
+			origin = process.env.ALLOW_ORIGIN;
 		}
 	}
 	response.setHeader('Access-Control-Allow-Origin', origin);

--- a/src/middleware/basic-cors.ts
+++ b/src/middleware/basic-cors.ts
@@ -23,8 +23,12 @@ export function basicCors(
 	if ('ALLOW_ORIGIN' in process.env && process.env.ALLOW_ORIGIN) {
 		if (process.env.ALLOW_ORIGIN.includes(', ')) {
 			// Array of Client URLs
-			const host = request.header('host').toLowerCase();
+			let host = request.headers.origin;
 			const clientUrls = process.env.ALLOW_ORIGIN.split(', ');
+
+			if (host instanceof Array) {
+				host = host[0];
+			}
 
 			if (clientUrls.includes(host)) {
 				origin = host;

--- a/src/models.ts
+++ b/src/models.ts
@@ -43,6 +43,7 @@
  */
 export { BaseModel, BaseModelInterface } from './models/base-model';
 export { BaseUser, BaseUserInterface } from './models/base-user';
+export { ExampleUser } from './models/example-user';
 
 export function getISOTime() {
 	return new Date(Date.now()).toISOString();

--- a/src/models/base-user.ts
+++ b/src/models/base-user.ts
@@ -1,134 +1,21 @@
 import { Request, Response } from 'express';
 import { hashSync } from 'bcryptjs';
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
-
-// Validation
-import {
-	Length,
-	IsEmail,
-	IsAlphanumeric,
-	IsDate,
-	IsOptional
-} from 'class-validator';
-
-// Bodyguards
-import {
-	AnyoneCanRead,
-	OnlySelfCanRead,
-	OnlySelfCanWrite,
-	OnlyAdminCanWrite,
-	BodyguardKey,
-	CanSearch
-} from '../bodyguard';
 
 // Models
 import { BaseModel } from './base-model';
-import { UserRole, UserStatus } from '../enums';
 
 /**
  * Base User
  */
-@Entity('User')
 export class BaseUser extends BaseModel {
-	// ID
-	@PrimaryGeneratedColumn()
-	@BodyguardKey()
-	@AnyoneCanRead()
-	public id: any = undefined;
-
-	// Time created
-	@Column({ type: 'timestamp', default: new Date() })
-	@IsDate()
-	@IsOptional()
-	@AnyoneCanRead()
-	public timeCreated: Date = undefined;
-
-	// Time last updated
-	@Column({ type: 'timestamp', default: new Date() })
-	@IsDate()
-	@IsOptional()
-	@AnyoneCanRead()
-	public timeUpdated: Date = undefined;
-
-	// Username
-	@Column({ unique: true })
-	@Length(4, 16)
-	@IsAlphanumeric()
-	@AnyoneCanRead()
-	@OnlySelfCanWrite()
-	@CanSearch()
-	public username: string = undefined;
-
-	// First name
-	@Column({ nullable: true })
-	@AnyoneCanRead()
-	@OnlySelfCanWrite()
-	@CanSearch()
-	public fname: string = undefined;
-
-	// Last name
-	@Column({ nullable: true })
-	@AnyoneCanRead()
-	@OnlySelfCanWrite()
-	@CanSearch()
-	public lname: string = undefined;
-
-	// Email
-	@Column({ nullable: true, unique: true })
-	@IsEmail()
-	@IsOptional()
-	@OnlySelfCanRead()
-	@OnlySelfCanWrite()
-	@CanSearch()
-	public email: string = undefined;
-
-	// Email (temporary)
-	@Column({ nullable: true })
-	@IsEmail()
-	@IsOptional()
-	@OnlySelfCanWrite()
-	public tempEmail: string = undefined;
-
-	// Password
-	@Column({ nullable: true })
-	@OnlySelfCanWrite()
-	public password: string = undefined;
-
-	// Password (temporary)
-	@Column({ nullable: true })
-	@OnlySelfCanWrite()
-	public tempPassword: string = undefined;
-
-	// BaseUser Role
-	@Column({ default: UserRole.Basic })
-	@AnyoneCanRead()
-	@OnlyAdminCanWrite()
-	public role: UserRole = undefined;
-
-	// BaseUser Status
-	@Column({ default: UserStatus.Pending })
-	@AnyoneCanRead()
-	@OnlyAdminCanWrite()
-	public status: UserStatus = undefined;
-
-	// Biography
-	// TODO: Validate
-	@Column({ type: 'text', nullable: true })
-	@AnyoneCanRead()
-	@OnlySelfCanWrite()
-	public biography: string = undefined;
-
-	// Geographical Location
-	@Column({ nullable: true })
-	@AnyoneCanRead()
-	@OnlySelfCanWrite()
-	public location: string = undefined;
-
-	// Thumbnail image
-	@Column({ nullable: true })
-	@AnyoneCanRead()
-	@OnlySelfCanWrite()
-	public thumbnail: string = undefined;
+	public id?: any = undefined;
+	public timeCreated?: Date = undefined;
+	public timeUpdated?: Date = undefined;
+	public username?: string = undefined;
+	public email?: string = undefined;
+	public password?: string = undefined;
+	public role?: any = undefined;
+	public status?: any = undefined;
 
 	// Post hook
 	public async beforePost(request: Request, response: Response) {

--- a/src/models/example-user.ts
+++ b/src/models/example-user.ts
@@ -26,7 +26,7 @@ import { UserRole, UserStatus } from '../enums';
 /**
  * Base User
  */
-@Entity()
+@Entity('User')
 export class ExampleUser extends BaseUser {
 	// ID
 	@PrimaryGeneratedColumn()

--- a/src/models/example-user.ts
+++ b/src/models/example-user.ts
@@ -1,41 +1,38 @@
-import {
-	Entity,
-	PrimaryGeneratedColumn,
-	Column,
-	OneToMany,
-	ManyToMany,
-	JoinTable
-} from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+// Validation
 import {
 	Length,
+	IsEmail,
 	IsAlphanumeric,
 	IsDate,
-	IsOptional,
-	Matches
+	IsOptional
 } from 'class-validator';
 
+// Bodyguards
 import {
-	BodyguardKey,
 	AnyoneCanRead,
 	OnlySelfCanRead,
 	OnlySelfCanWrite,
 	OnlyAdminCanWrite,
-	CanSearch,
-	CanReadRelation
-} from '../../../../src/bodyguard';
+	BodyguardKey,
+	CanSearch
+} from '../bodyguard';
 
-import { BaseUser } from '../../../../src/models';
-import { UserRole, UserStatus, BodyguardOwner } from '../../../../src/enums';
+// Models
+import { BaseUser } from './base-user';
+import { UserRole, UserStatus } from '../enums';
 
-import { Term } from './term';
-
+/**
+ * Base User
+ */
 @Entity()
-export class User extends BaseUser {
+export class ExampleUser extends BaseUser {
 	// ID
 	@PrimaryGeneratedColumn()
 	@BodyguardKey()
 	@AnyoneCanRead()
-	public id: number = undefined;
+	public id: any = undefined;
 
 	// Time created
 	@Column({ type: 'timestamp', default: new Date() })
@@ -44,7 +41,7 @@ export class User extends BaseUser {
 	@AnyoneCanRead()
 	public timeCreated: Date = undefined;
 
-	// Time last accessed
+	// Time last updated
 	@Column({ type: 'timestamp', default: new Date() })
 	@IsDate()
 	@IsOptional()
@@ -62,8 +59,6 @@ export class User extends BaseUser {
 
 	// First name
 	@Column({ nullable: true })
-	@Length(1, 250)
-	@IsOptional()
 	@AnyoneCanRead()
 	@OnlySelfCanWrite()
 	@CanSearch()
@@ -71,8 +66,6 @@ export class User extends BaseUser {
 
 	// Last name
 	@Column({ nullable: true })
-	@Length(1, 250)
-	@IsOptional()
 	@AnyoneCanRead()
 	@OnlySelfCanWrite()
 	@CanSearch()
@@ -80,7 +73,7 @@ export class User extends BaseUser {
 
 	// Email
 	@Column({ nullable: true, unique: true })
-	@Matches(/^\w+@[0-9a-zA-Z_]+?\.[a-zA-Z]+$/i)
+	@IsEmail()
 	@IsOptional()
 	@OnlySelfCanRead()
 	@OnlySelfCanWrite()
@@ -89,42 +82,36 @@ export class User extends BaseUser {
 
 	// Password
 	@Column({ nullable: true })
-	@Length(1, 250)
-	@IsOptional()
 	@OnlySelfCanWrite()
-	@Matches(/[A-za-z0-9!@#$%^&*()-_+={};:'",<.>/?]{8,20}/)
 	public password: string = undefined;
 
-	// BaseUser Role
+	// ExampleUser Role
 	@Column({ default: UserRole.Basic })
-	@Length(1, 250)
-	@IsOptional()
 	@AnyoneCanRead()
 	@OnlyAdminCanWrite()
 	public role: UserRole = undefined;
 
-	// BaseUser Status
+	// ExampleUser Status
 	@Column({ default: UserStatus.Pending })
-	@Length(1, 250)
-	@IsOptional()
 	@AnyoneCanRead()
 	@OnlyAdminCanWrite()
 	public status: UserStatus = undefined;
 
 	// Biography
 	@Column({ type: 'text', nullable: true })
-	@Length(1, 5000)
-	@IsOptional()
 	@AnyoneCanRead()
 	@OnlySelfCanWrite()
 	public biography: string = undefined;
 
-	@OneToMany((type) => Term, (term) => term.author)
-	public terms: Term[] = undefined;
-
-	@ManyToMany((type) => Term, (term) => term.users)
-	@JoinTable()
-	@CanReadRelation()
+	// Geographical Location
+	@Column({ nullable: true })
+	@AnyoneCanRead()
 	@OnlySelfCanWrite()
-	public termRelations: Term[] = undefined;
+	public location: string = undefined;
+
+	// Thumbnail image
+	@Column({ nullable: true })
+	@AnyoneCanRead()
+	@OnlySelfCanWrite()
+	public thumbnail: string = undefined;
 }

--- a/src/pointy-core.ts
+++ b/src/pointy-core.ts
@@ -71,7 +71,6 @@ export class PointyApi {
 		// Default db
 		this.db = new PointyPostgres();
 		this.db.logger = this.log;
-		this.db.errorHandler = this.error;
 
 		if (process.argv.includes('testmode')) {
 			this.testmode = true;

--- a/src/pointy-core.ts
+++ b/src/pointy-core.ts
@@ -75,6 +75,35 @@ export class PointyApi {
 		this.app.on('error', (error) => this.error(error));
 	}
 
+	// Ready check
+	public readycheck() {
+		// Check pointy.userType
+		if (!this.userType) {
+			console.warn('[PointyAPI] pointy.userType has not been set!');
+
+			return false;
+		}
+
+		// Check database connection
+		if (!this.db || !this.db.conn) {
+			console.warn(
+				'[PointyAPI] Database connection has not been established'
+			);
+
+			return false;
+		}
+
+		// Check database entities
+		if (!this.db.entities || !this.db.entities.length) {
+			console.warn('[PointyAPI] Database does not contain any entities');
+
+			return false;
+		}
+
+		// Checks passed
+		return true;
+	}
+
 	// Start
 	public async start() {
 		// Set proper headers
@@ -97,13 +126,19 @@ export class PointyApi {
 		this.app.use(bodyParser.json());
 		this.app.use(bodyParser.urlencoded({ extended: true }));
 
-		// Run start function
+		// Run before function
 		await this.before(this.app);
 
-		// Server listen
-		this.listen(this.app, process.env.PORT, this.log);
+		// Ready check
+		if (this.readycheck()) {
+			// Server listen
+			this.listen(this.app, process.env.PORT, this.log);
 
-		this.ready(this.app);
+			this.ready(this.app);
+		}
+		else {
+			process.exit();
+		}
 	}
 }
 

--- a/src/pointy-core.ts
+++ b/src/pointy-core.ts
@@ -29,7 +29,7 @@ import { logHandler, errorHandler } from './handlers';
 import { bindResponders } from './utils/bind-responders';
 
 // Base Models
-import { BaseUser, BaseUserInterface } from './models';
+import { BaseUserInterface, ExampleUser, BaseUser } from './models';
 
 /**
  * PointyAPI App Instance
@@ -42,7 +42,7 @@ export class PointyApi {
 	public listen: Function = listen;
 	public db: BaseDb;
 	public http = new HttpClient();
-	public userType: BaseUserInterface = BaseUser;
+	public userType: BaseUserInterface = ExampleUser;
 
 	// Middleware
 
@@ -96,6 +96,13 @@ export class PointyApi {
 		// Check database entities
 		if (!this.db.entities || !this.db.entities.length) {
 			console.warn('[PointyAPI] Database does not contain any entities');
+
+			return false;
+		}
+
+		// Check for database entity of BaseUser
+		if (this.db.entities.includes(BaseUser)) {
+			console.warn('[PointyAPI] BaseUser is not a valid database entity');
 
 			return false;
 		}

--- a/src/pointy-core.ts
+++ b/src/pointy-core.ts
@@ -141,6 +141,12 @@ export class PointyApi {
 			// Server listen
 			this.listen(this.app, process.env.PORT, this.log);
 
+			// Send IPC notification
+			if ('send' in process && process.send) {
+				process.send('server-ready');
+			}
+
+			// Run ready callback
 			this.ready(this.app);
 		}
 		else {

--- a/src/pointy-core.ts
+++ b/src/pointy-core.ts
@@ -43,6 +43,7 @@ export class PointyApi {
 	public db: BaseDb;
 	public http = new HttpClient();
 	public userType: BaseUserInterface = ExampleUser;
+	public testmode: boolean = false;
 
 	// Middleware
 
@@ -71,6 +72,10 @@ export class PointyApi {
 		this.db = new PointyPostgres();
 		this.db.logger = this.log;
 		this.db.errorHandler = this.error;
+
+		if (process.argv.includes('testmode')) {
+			this.testmode = true;
+		}
 
 		this.app.on('error', (error) => this.error(error));
 	}

--- a/src/query-tools/get-query.ts
+++ b/src/query-tools/get-query.ts
@@ -15,7 +15,7 @@ export async function getQuery(
 ): Promise<any> {
 	if ('query' in request && 'id' in request.query && request.query.id) {
 		// Read one
-		return await request.repository.findOne(request.query.id);
+		return request.repository.findOne(request.query.id);
 	}
 	else if ('query' in request && Object.keys(request.query).length) {
 		// Read query
@@ -172,12 +172,12 @@ export async function getQuery(
 		}
 
 		if ('raw' in request.query && request.query.raw) {
-			return await query.getRawMany();
+			return query.getRawMany();
 		}
 		else if (groupByKeys.length) {
 			const prestring = `obj_`;
 
-			return await query.getRawMany().then((result) => {
+			return query.getRawMany().then((result) => {
 				if (result instanceof Array && result.length) {
 					result = result.map((resource) => {
 						const obj = new request.payloadType();
@@ -194,11 +194,11 @@ export async function getQuery(
 			});
 		}
 		else {
-			return await query.getMany();
+			return query.getMany();
 		}
 	}
 	else {
 		// Read all
-		return await request.repository.find();
+		return request.repository.find();
 	}
 }

--- a/src/test-probe/create-mock-request.ts
+++ b/src/test-probe/create-mock-request.ts
@@ -1,6 +1,6 @@
 import { mockRequest, mockResponse } from 'mock-req-res';
 import { getRepository } from 'typeorm';
-import { BaseUser } from '../models/base-user';
+import { ExampleUser } from '../models';
 
 declare var fail;
 
@@ -16,11 +16,11 @@ export function createMockRequest(
 ) {
 	// Create request
 	const request = mockRequest();
-	request.repository = getRepository(BaseUser);
+	request.repository = getRepository(ExampleUser);
 	request.method = method;
 	request.baseUrl = url;
-	request.userType = BaseUser;
-	request.payloadType = BaseUser;
+	request.userType = ExampleUser;
+	request.payloadType = ExampleUser;
 	request.joinMembers = [];
 	request.identifier = 'id';
 	request.header = (key) => (key === 'host' ? 'localhost' : false);

--- a/src/utils/fork-server.ts
+++ b/src/utils/fork-server.ts
@@ -44,14 +44,17 @@ import { fork } from 'child_process';
  * @param serverFile File path to the server entry-point
  * @return Returns a Promise
  */
-export function forkServer(serverFile: string): Promise<any> {
+export function forkServer(
+	serverFile: string,
+	args: string[] = [ 'testmode' ]
+): Promise<any> {
 	return new Promise((accept, reject) => {
 		fs.access(serverFile, (error) => {
 			if (error) {
 				reject('Could not read server file: ' + JSON.stringify(error));
 			}
 			else {
-				const serverfork = fork(serverFile);
+				const serverfork = fork(serverFile, args);
 
 				serverfork.on('message', (message) => {
 					accept(serverfork);

--- a/src/utils/fork-server.ts
+++ b/src/utils/fork-server.ts
@@ -26,7 +26,7 @@ import * as fs from 'fs';
  * describe('API Server', () => {
  * 	it('is running', async () => {
  * 		await http
- * 			.get('/', {}, [ 200, 404 ])
+ * 			.get('/', {}, undefined, [ 200, 404 ])
  * 			.catch((error) => fail(error));
  * 	});
  * });

--- a/src/utils/listen.ts
+++ b/src/utils/listen.ts
@@ -23,10 +23,5 @@ export async function listen(
 	await app.listen(port, () => {
 		logger('Server started.');
 		logger(`Server listening on port ${port}`);
-
-		// Send IPC notification
-		if ('send' in process && process.send) {
-			process.send('server-ready');
-		}
 	});
 }

--- a/src/utils/run-hook.ts
+++ b/src/utils/run-hook.ts
@@ -44,6 +44,7 @@ export async function runHook(
 		})
 		.catch((error) => {
 			hookResult = false;
+			console.error(error);
 		});
 
 	if (!hookResult) {

--- a/test/examples/api/models/example-owner.ts
+++ b/test/examples/api/models/example-owner.ts
@@ -1,21 +1,37 @@
 import { BaseUser } from '../../../../src/models';
 import { ExampleRelation } from './example-relation';
 
-import { Entity, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
-import { AnyoneCanRead, OnlyAdminCanRead } from '../../../../src/bodyguard';
+import { Entity, PrimaryGeneratedColumn, OneToMany, Column } from 'typeorm';
+import {
+	BodyguardKey,
+	AnyoneCanRead,
+	OnlyAdminCanRead
+} from '../../../../src/bodyguard';
 import { UserRole } from '../../../../src/enums';
 
 /**
  * Foregin key test class - Owner
  */
-@Entity('ExampleOwner')
+@Entity()
 export class ExampleOwner extends BaseUser {
 	// ID
-	@PrimaryGeneratedColumn() public id: number = undefined;
+	@PrimaryGeneratedColumn()
+	@BodyguardKey()
+	@AnyoneCanRead()
+	public id: number = undefined;
 
-	@AnyoneCanRead() public username: string = undefined;
+	@Column()
+	@AnyoneCanRead()
+	public username: string = undefined;
 
-	@OnlyAdminCanRead() public role: UserRole = undefined;
+	@Column({ default: UserRole.Basic })
+	@OnlyAdminCanRead()
+	public role: UserRole = undefined;
+
+	@Column({ nullable: true })
+	public fname: string = undefined;
+	@Column({ nullable: true })
+	public lname: string = undefined;
 
 	// ExampleRelation
 	@OneToMany((type) => ExampleRelation, (relation) => relation.owner)

--- a/test/examples/api/models/example-relation.ts
+++ b/test/examples/api/models/example-relation.ts
@@ -2,16 +2,22 @@ import { BaseModel } from '../../../../src/models';
 import { ExampleOwner } from './example-owner';
 
 import { Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
-import { CanSearchRelation, BodyguardKey } from '../../../../src/bodyguard';
+import {
+	CanSearchRelation,
+	BodyguardKey,
+	AnyoneCanRead
+} from '../../../../src/bodyguard';
 import { BodyguardOwner } from '../../../../src/enums';
 
 /**
  * Foregin key test class - Resource
  */
-@Entity('ExampleRelation')
+@Entity()
 export class ExampleRelation extends BaseModel {
 	// ID
-	@PrimaryGeneratedColumn() public id: number = undefined;
+	@PrimaryGeneratedColumn()
+	@AnyoneCanRead()
+	public id: number = undefined;
 
 	// ExampleOwner
 	@ManyToOne((type) => ExampleOwner, (owner) => owner.relations)

--- a/test/examples/api/models/hook-test-class.ts
+++ b/test/examples/api/models/hook-test-class.ts
@@ -1,9 +1,19 @@
 import { Request, Response } from 'express';
 import { BaseUser } from '../../../../src/models';
-import { Entity } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { BodyguardKey, AnyoneCanRead } from '../../../../src/bodyguard';
 
-@Entity('HookTestClass')
+@Entity()
 export class HookTestClass extends BaseUser {
+	@PrimaryGeneratedColumn()
+	@BodyguardKey()
+	@AnyoneCanRead()
+	public id: number = undefined;
+
+	@Column() public username: string = undefined;
+	@Column() public password: string = undefined;
+	@Column() public email: string = undefined;
+
 	public async beforePost(request: Request, response: Response) {
 		expect(this.id).toBe(undefined);
 		expect(this.username).toBe('beforePost');

--- a/test/examples/api/server.ts
+++ b/test/examples/api/server.ts
@@ -1,7 +1,9 @@
 import { pointy } from '../../../src';
 import { basicCors, loadUser } from '../../../src/middleware';
-import { BaseUser } from '../../../src/models/base-user';
+import { ExampleUser } from '../../../src/models/example-user';
 const ROOT_PATH = require('app-root-path').toString();
+
+pointy.userType = ExampleUser;
 
 // Setup
 pointy.before = async (app) => {
@@ -13,7 +15,7 @@ pointy.before = async (app) => {
 
 	// Database
 	await pointy.db
-		.setEntities([ BaseUser ])
+		.setEntities([ ExampleUser ])
 		.connect(ROOT_PATH)
 		.catch((error) => pointy.error(error));
 };

--- a/test/examples/basic/routes/user.ts
+++ b/test/examples/basic/routes/user.ts
@@ -6,14 +6,14 @@ import {
 	deleteEndpoint,
 	getEndpoint
 } from '../../../../src/endpoints';
-import { BaseUser } from '../../../../src/models/base-user';
+import { ExampleUser } from '../../../../src/models/example-user';
 
 import { setModel } from '../../../../src/';
 
 const router: Router = Router();
 
 async function loader(request, response, next) {
-	if (await setModel(request, response, BaseUser)) {
+	if (await setModel(request, response, ExampleUser)) {
 		next();
 	}
 }

--- a/test/examples/basic/server.ts
+++ b/test/examples/basic/server.ts
@@ -1,10 +1,12 @@
 import { pointy } from '../../../src';
 import { basicCors, loadUser } from '../../../src/middleware';
-import { BaseUser } from '../../../src/models/base-user';
+import { ExampleUser } from '../../../src/models/example-user';
 const ROOT_PATH = require('app-root-path').toString();
 
 // Routes
 import { userRouter } from './routes/user';
+
+pointy.userType = ExampleUser;
 
 // Setup
 pointy.before = async (app) => {
@@ -19,7 +21,7 @@ pointy.before = async (app) => {
 
 	// Database
 	await pointy.db
-		.setEntities([ BaseUser ])
+		.setEntities([ ExampleUser ])
 		.connect(ROOT_PATH)
 		.catch((error) => pointy.error(error));
 };

--- a/test/examples/chat/models/chat-message.ts
+++ b/test/examples/chat/models/chat-message.ts
@@ -29,7 +29,7 @@ import { User } from './user';
 import { ChatStatus } from '../enums/chat-status';
 import { BodyguardOwner } from '../../../../src/enums';
 
-@Entity('ChatMessage')
+@Entity()
 export class ChatMessage extends BaseModel {
 	// ID
 	@PrimaryGeneratedColumn()
@@ -83,8 +83,6 @@ export class ChatMessage extends BaseModel {
 	public timeUpdated: Date = undefined;
 
 	// Message body
-	// TODO: Validate
-
 	@Column({ type: 'text' })
 	@OnlySelfCanRead()
 	@OnlySelfCanWrite()

--- a/test/examples/chat/models/user.ts
+++ b/test/examples/chat/models/user.ts
@@ -26,7 +26,7 @@ import {
 import { BaseUser } from '../../../../src/models';
 import { BodyguardOwner, UserRole, UserStatus } from '../../../../src/enums';
 
-@Entity('User')
+@Entity()
 export class User extends BaseUser {
 	// ID
 	@PrimaryGeneratedColumn()
@@ -84,26 +84,12 @@ export class User extends BaseUser {
 	@CanSearch()
 	public email: string = undefined;
 
-	// Email (temporary)
-	@Column({ nullable: true })
-	@IsEmail()
-	@IsOptional()
-	@OnlySelfCanWrite()
-	public tempEmail: string = undefined;
-
 	// Password
 	@Column({ nullable: true })
 	@Length(1, 250)
 	@IsOptional()
 	@OnlySelfCanWrite()
 	public password: string = undefined;
-
-	// Password (temporary)
-	@Column({ nullable: true })
-	@Length(1, 250)
-	@IsOptional()
-	@OnlySelfCanWrite()
-	public tempPassword: string = undefined;
 
 	// BaseUser Role
 	@Column({ default: UserRole.Basic })
@@ -122,7 +108,6 @@ export class User extends BaseUser {
 	public status: UserStatus = undefined;
 
 	// Biography
-	// TODO: Validate
 	@Column({ type: 'text', nullable: true })
 	@IsOptional()
 	@AnyoneCanRead()

--- a/test/examples/guards/routes/auth.ts
+++ b/test/examples/guards/routes/auth.ts
@@ -1,14 +1,14 @@
 import { Router } from 'express';
 
 import { loginEndpoint, logoutEndpoint } from '../../../../src/endpoints';
-import { BaseUser } from '../../../../src/models/base-user';
+import { ExampleUser } from '../../../../src/models/example-user';
 
 import { setModel } from '../../../../src/';
 
 const router: Router = Router();
 
 async function loader(request, response, next) {
-	if (await setModel(request, response, BaseUser, true)) {
+	if (await setModel(request, response, ExampleUser, true)) {
 		next();
 	}
 }

--- a/test/examples/guards/routes/user.ts
+++ b/test/examples/guards/routes/user.ts
@@ -6,7 +6,7 @@ import {
 	deleteEndpoint,
 	getEndpoint
 } from '../../../../src/endpoints';
-import { BaseUser } from '../../../../src/models/base-user';
+import { ExampleUser } from '../../../../src/models/example-user';
 
 import { setModel } from '../../../../src/';
 
@@ -16,7 +16,7 @@ import { onlySelf } from '../../../../src/guards';
 const router: Router = Router();
 
 async function loader(request, response, next) {
-	if (await setModel(request, response, BaseUser)) {
+	if (await setModel(request, response, ExampleUser)) {
 		next();
 	}
 }

--- a/test/examples/guards/server.ts
+++ b/test/examples/guards/server.ts
@@ -1,11 +1,13 @@
 import { pointy } from '../../../src';
 import { basicCors, loadUser } from '../../../src/middleware';
-import { BaseUser } from '../../../src/models/base-user';
+import { ExampleUser } from '../../../src/models/example-user';
 const ROOT_PATH = require('app-root-path').toString();
 
 // Routes
 import { userRouter } from './routes/user';
 import { authRouter } from './routes/auth';
+
+pointy.userType = ExampleUser;
 
 // Setup
 pointy.before = async (app) => {
@@ -21,7 +23,7 @@ pointy.before = async (app) => {
 
 	// Database
 	await pointy.db
-		.setEntities([ BaseUser ])
+		.setEntities([ ExampleUser ])
 		.connect(ROOT_PATH)
 		.catch((error) => pointy.error(error));
 };

--- a/test/spec/api/bodyguard/compare-id-to-user.spec.ts
+++ b/test/spec/api/bodyguard/compare-id-to-user.spec.ts
@@ -1,4 +1,4 @@
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { getBodyguardKeys, compareIdToUser } from '../../../../src/bodyguard';
 
 /**
@@ -8,11 +8,11 @@ import { getBodyguardKeys, compareIdToUser } from '../../../../src/bodyguard';
 describe('[Bodyguard] compareIdToUser', () => {
 	beforeAll(() => {
 		// Create user
-		this.user = new BaseUser();
+		this.user = new ExampleUser();
 		this.user.id = 2;
 
 		// Get bodyguard keys
-		this.guardKeys = getBodyguardKeys(new BaseUser());
+		this.guardKeys = getBodyguardKeys(new ExampleUser());
 	});
 
 	it('returns true if the user matches', () => {

--- a/test/spec/api/bodyguard/compare-nested.spec.ts
+++ b/test/spec/api/bodyguard/compare-nested.spec.ts
@@ -1,4 +1,4 @@
-import { BaseModel, BaseUser } from '../../../../src/models';
+import { BaseModel, ExampleUser } from '../../../../src/models';
 import {
 	getBodyguardKeys,
 	compareNestedBodyguards,
@@ -6,7 +6,7 @@ import {
 } from '../../../../src/bodyguard';
 
 class TestModel extends BaseModel {
-	@BodyguardKey() public owner: BaseUser = undefined;
+	@BodyguardKey() public owner: ExampleUser = undefined;
 }
 
 /**
@@ -16,7 +16,7 @@ class TestModel extends BaseModel {
 describe('[Bodyguard] compareNested()', () => {
 	it('returns true if the object matches', () => {
 		// Create base user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 2;
 
 		// Create comparator user
@@ -40,11 +40,11 @@ describe('[Bodyguard] compareNested()', () => {
 
 	it('returns false if the object does not match', () => {
 		// Create base user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 2;
 
 		// Create another base user
-		const user2 = new BaseUser();
+		const user2 = new ExampleUser();
 		user.id = 3;
 
 		// Create a resource belonging to user

--- a/test/spec/api/bodyguard/get-bodyguard-keys.spec.ts
+++ b/test/spec/api/bodyguard/get-bodyguard-keys.spec.ts
@@ -1,4 +1,4 @@
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { getBodyguardKeys } from '../../../../src/bodyguard';
 
 /**
@@ -6,9 +6,9 @@ import { getBodyguardKeys } from '../../../../src/bodyguard';
  * pointyapi/bodyguard
  */
 describe('[Bodyguard] getBodyguardKeys', () => {
-	it('returns an array of one key for BaseUser', () => {
+	it('returns an array of one key for ExampleUser', () => {
 		// Get bodyguard keys
-		const ownerKeys = getBodyguardKeys(new BaseUser());
+		const ownerKeys = getBodyguardKeys(new ExampleUser());
 
 		// Expect keys to be an array of strings
 		expect(ownerKeys).toEqual(jasmine.any(Array));

--- a/test/spec/api/bodyguard/get-readable-fields.spec.ts
+++ b/test/spec/api/bodyguard/get-readable-fields.spec.ts
@@ -1,4 +1,4 @@
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { getReadableFields } from '../../../../src/bodyguard';
 
 /**
@@ -6,9 +6,9 @@ import { getReadableFields } from '../../../../src/bodyguard';
  * pointyapi/bodyguard
  */
 describe('[Bodyguard] getReadableFields', () => {
-	it('returns an array of one key for BaseUser', () => {
+	it('returns an array of one key for ExampleUser', () => {
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 1;
 
 		// Get readable fields

--- a/test/spec/api/bodyguard/get-readable-relations.spec.ts
+++ b/test/spec/api/bodyguard/get-readable-relations.spec.ts
@@ -4,11 +4,11 @@ import {
 	getReadableRelations,
 	CanReadRelation
 } from '../../../../src/bodyguard';
-import { BaseModel, BaseUser } from '../../../../src/models';
+import { BaseModel, ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums';
 
 class AnyoneCanReadRelationModel extends BaseModel {
-	@CanReadRelation() public anyoneCanRead: BaseUser = undefined;
+	@CanReadRelation() public anyoneCanRead: ExampleUser = undefined;
 }
 
 /**

--- a/test/spec/api/bodyguard/get-searchable-fields.spec.ts
+++ b/test/spec/api/bodyguard/get-searchable-fields.spec.ts
@@ -1,4 +1,4 @@
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { getSearchableFields } from '../../../../src/bodyguard';
 
 /**
@@ -6,9 +6,9 @@ import { getSearchableFields } from '../../../../src/bodyguard';
  * pointyapi/bodyguard
  */
 describe('[Bodyguard] getSearchableFields', () => {
-	it('returns an array of one key for BaseUser', () => {
+	it('returns an array of one key for ExampleUser', () => {
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 1;
 
 		// Get readable fields

--- a/test/spec/api/bodyguard/get-searchable-relations.spec.ts
+++ b/test/spec/api/bodyguard/get-searchable-relations.spec.ts
@@ -7,7 +7,7 @@ import { getSearchableRelations } from '../../../../src/bodyguard';
  * pointyapi/bodyguard
  */
 describe('[Bodyguard] getSearchableRelations', () => {
-	it('returns an array of one key for BaseUser', () => {
+	it('returns an array of one key for ExampleUser', () => {
 		// Create user
 		const user = new User();
 		user.id = 1;

--- a/test/spec/api/bodyguard/read-filter.spec.ts
+++ b/test/spec/api/bodyguard/read-filter.spec.ts
@@ -4,7 +4,7 @@ import {
 	OnlySelfCanRead
 } from '../../../../src/bodyguard';
 
-import { BaseModel, BaseUser } from '../../../../src/models';
+import { BaseModel, ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums';
 import { ChatMessage } from '../../../examples/chat/models/chat-message';
 import { User } from '../../../examples/chat/models/user';
@@ -16,12 +16,12 @@ import { User } from '../../../examples/chat/models/user';
 describe('[Bodyguard] readFilter', () => {
 	it('filters unauthorized requests', () => {
 		// Create user
-		let user = new BaseUser();
+		let user = new ExampleUser();
 		user.id = 1;
 		user.email = 'test@example.com';
 
 		// Filter user object
-		user = readFilter(user, new BaseUser(), BaseUser, BaseUser);
+		user = readFilter(user, new ExampleUser(), ExampleUser, ExampleUser);
 
 		// Check if filtered
 		expect(user.email).toEqual(undefined);
@@ -29,12 +29,12 @@ describe('[Bodyguard] readFilter', () => {
 
 	it('bypasses authorized requests', () => {
 		// Create user
-		let user = new BaseUser();
+		let user = new ExampleUser();
 		user.id = 1;
 		user.email = 'test@example.com';
 
 		// Filter user object
-		user = readFilter(user, user, BaseUser, BaseUser);
+		user = readFilter(user, user, ExampleUser, ExampleUser);
 
 		// Expect the object to be unfiltered
 		expect(user.email).toEqual('test@example.com');
@@ -42,18 +42,18 @@ describe('[Bodyguard] readFilter', () => {
 
 	it('bypasses admin requests', () => {
 		// Create admin user
-		const user1 = new BaseUser();
+		const user1 = new ExampleUser();
 		user1.id = 1;
 		user1.role = UserRole.Admin;
 
 		// Create basic user
-		let user2 = new BaseUser();
+		let user2 = new ExampleUser();
 		user2.id = 2;
 		user2.role = UserRole.Basic;
 		user2.email = 'test@example.com';
 
 		// Filter user object
-		user2 = readFilter(user2, user1, BaseUser, BaseUser);
+		user2 = readFilter(user2, user1, ExampleUser, ExampleUser);
 
 		// Expect the result to be unfiltered
 		expect(user2.email).toEqual('test@example.com');
@@ -83,7 +83,7 @@ describe('[Bodyguard] readFilter', () => {
 
 		// Filter resources
 		let results = [ test1, test2 ];
-		results = readFilter(results, user3, BaseUser, BaseUser);
+		results = readFilter(results, user3, ExampleUser, ExampleUser);
 
 		// Expect result to be filtered properly
 		expect(results).toEqual(jasmine.any(Array));

--- a/test/spec/api/bodyguard/write-filter.spec.ts
+++ b/test/spec/api/bodyguard/write-filter.spec.ts
@@ -4,7 +4,7 @@ import {
 	OnlySelfCanRead
 } from '../../../../src/bodyguard';
 
-import { BaseModel, BaseUser } from '../../../../src/models';
+import { BaseModel, ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums';
 import { ChatMessage } from '../../../examples/chat/models/chat-message';
 import { User } from '../../../examples/chat/models/user';
@@ -18,9 +18,9 @@ describe('[Bodyguard] writeFilter', () => {
 		// Filter user object
 		const result = writeFilter(
 			{ email: 'test@example.com' },
-			new BaseUser(),
-			BaseUser,
-			BaseUser,
+			new ExampleUser(),
+			ExampleUser,
+			ExampleUser,
 			false
 		);
 
@@ -32,9 +32,9 @@ describe('[Bodyguard] writeFilter', () => {
 		// Filter user object
 		const result = writeFilter(
 			{ email: 'test@example.com' },
-			new BaseUser(),
-			BaseUser,
-			BaseUser,
+			new ExampleUser(),
+			ExampleUser,
+			ExampleUser,
 			true
 		);
 
@@ -44,7 +44,7 @@ describe('[Bodyguard] writeFilter', () => {
 
 	it('bypasses admin requests', () => {
 		// Create admin user
-		const admin = new BaseUser();
+		const admin = new ExampleUser();
 		admin.id = 1;
 		admin.role = UserRole.Admin;
 
@@ -52,8 +52,8 @@ describe('[Bodyguard] writeFilter', () => {
 		const result = writeFilter(
 			{ email: 'test@example.com' },
 			admin,
-			BaseUser,
-			BaseUser
+			ExampleUser,
+			ExampleUser
 		);
 
 		// Expect the result to be unfiltered
@@ -84,7 +84,7 @@ describe('[Bodyguard] writeFilter', () => {
 
 		// Filter resources
 		const results = [ test1, test2 ];
-		const result = writeFilter(results, user3, BaseUser, BaseUser);
+		const result = writeFilter(results, user3, ExampleUser, ExampleUser);
 
 		// Expect result to be filtered properly
 		expect(result).toBe('[#0]id');

--- a/test/spec/api/database/base-db.spec.ts
+++ b/test/spec/api/database/base-db.spec.ts
@@ -37,15 +37,4 @@ describe('[BaseDb]', () => {
 		this.baseDb.logger();
 		expect(result).toBe(true);
 	});
-
-	it('can log an error', () => {
-		let result = false;
-
-		console.error = () => {
-			result = true;
-		};
-
-		this.baseDb.errorHandler();
-		expect(result).toBe(true);
-	});
 });

--- a/test/spec/api/database/postgres.spec.ts
+++ b/test/spec/api/database/postgres.spec.ts
@@ -1,5 +1,5 @@
 import { PointyPostgres } from '../../../../src/database';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import * as path from 'path';
 const ROOT_PATH = require('app-root-path').toString();
 
@@ -24,7 +24,7 @@ describe('[Database: Postgres]', async () => {
 	});
 
 	it('can set entities', () => {
-		this.db.setEntities([ BaseUser ]);
+		this.db.setEntities([ ExampleUser ]);
 	});
 
 	it('can connect', async () => {

--- a/test/spec/api/database/postgres.spec.ts
+++ b/test/spec/api/database/postgres.spec.ts
@@ -35,7 +35,6 @@ describe('[Database: Postgres]', async () => {
 	it('can connect with json options', async () => {
 		const db = new PointyPostgres();
 		db.connectionName = 'jsonconn';
-		db.errorHandler = (error) => fail(error);
 		db.logger = () => {};
 
 		// Database

--- a/test/spec/api/endpoints/delete-endpoint.spec.ts
+++ b/test/spec/api/endpoints/delete-endpoint.spec.ts
@@ -1,11 +1,13 @@
 import { setModel } from '../../../../src';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { deleteEndpoint } from '../../../../src/endpoints';
 
 import { createMockRequest } from '../../../../src/test-probe';
 import { HookTestClass } from '../../../examples/api/models/hook-test-class';
 import { addResource } from '../../../../src/utils';
 import { getRepository } from 'typeorm';
+
+const errorHandler = (error) => fail(JSON.stringify(error));
 
 /**
  * deleteEndpoint()
@@ -26,7 +28,7 @@ describe('[Endpoints] Delete', () => {
 		const { request, response } = createMockRequest('DELETE');
 
 		// Create base user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.fname = 'Delete';
 		user.lname = 'Endpoint';
 		user.username = 'deleteEndpoint';
@@ -34,24 +36,20 @@ describe('[Endpoints] Delete', () => {
 		user.email = 'delete@example.com';
 
 		// Get user repo
-		const result = await request.repository
-			.save(user)
-			.catch((error) => fail(JSON.stringify(error)));
+		const result = await request.repository.save(user).catch(errorHandler);
 
 		// Setup request
 		request.identifier = 'id';
 		request.params = result;
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
 		// Test delete responder
 		response.deleteResponder = () => {};
-		await deleteEndpoint(request, response).catch((error) =>
-			fail(JSON.stringify(error))
-		);
+		await deleteEndpoint(request, response).catch(errorHandler);
 	});
 
 	it('calls response.goneResponder() if object not found', async () => {

--- a/test/spec/api/endpoints/get-endpoint.spec.ts
+++ b/test/spec/api/endpoints/get-endpoint.spec.ts
@@ -1,5 +1,5 @@
 import { setModel } from '../../../../src';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { getEndpoint } from '../../../../src/endpoints';
 
 import { createMockRequest } from '../../../../src/test-probe';
@@ -23,14 +23,14 @@ describe('[Endpoints] Get', () => {
 
 	beforeAll(() => {
 		// Create users
-		this.user1 = new BaseUser();
+		this.user1 = new ExampleUser();
 		this.user1.fname = 'Get';
 		this.user1.lname = 'Endpoint';
 		this.user1.username = 'getEndpoint1';
 		this.user1.password = 'password123';
 		this.user1.email = 'get1@example.com';
 
-		this.user2 = new BaseUser();
+		this.user2 = new ExampleUser();
 		this.user2.fname = 'Get';
 		this.user2.lname = 'Endpoint';
 		this.user2.username = 'getEndpoint2';
@@ -44,7 +44,7 @@ describe('[Endpoints] Get', () => {
 		request.query.search = 'Get';
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -70,7 +70,7 @@ describe('[Endpoints] Get', () => {
 		request.query.count = true;
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -94,7 +94,7 @@ describe('[Endpoints] Get', () => {
 		request.query.search = 'Get';
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -103,7 +103,7 @@ describe('[Endpoints] Get', () => {
 
 		// Check for getResponder()
 		response.getResponder = (result) => {
-			expect(result).toEqual(jasmine.any(BaseUser));
+			expect(result).toEqual(jasmine.any(ExampleUser));
 		};
 
 		// Run request

--- a/test/spec/api/endpoints/logout-endpoint.spec.ts
+++ b/test/spec/api/endpoints/logout-endpoint.spec.ts
@@ -1,7 +1,7 @@
 import { getRepository } from 'typeorm';
 import { hashSync } from 'bcryptjs';
 
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { logoutEndpoint, loginEndpoint } from '../../../../src/endpoints';
 import { createMockRequest } from '../../../../src/test-probe';
 import { HookTestClass } from '../../../examples/api/models/hook-test-class';
@@ -23,14 +23,14 @@ describe('[Endpoints] Logout', async () => {
 
 	beforeAll(async () => {
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.fname = 'Logout';
 		user.lname = 'Test';
 		user.username = 'logouttest';
 		user.password = hashSync('password123', 12);
 		user.email = 'logouttest@example.com';
 
-		await getRepository(BaseUser)
+		await getRepository(ExampleUser)
 			.save(user)
 			.catch((error) => fail(JSON.stringify(error)));
 	});

--- a/test/spec/api/endpoints/patch-endpoint.spec.ts
+++ b/test/spec/api/endpoints/patch-endpoint.spec.ts
@@ -1,5 +1,5 @@
 import { setModel } from '../../../../src';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { patchEndpoint } from '../../../../src/endpoints';
 import { createMockRequest } from '../../../../src/test-probe';
 import { HookTestClass } from '../../../examples/api/models/hook-test-class';
@@ -25,7 +25,7 @@ describe('[Endpoints] Patch', () => {
 		const { request, response } = createMockRequest('PATCH');
 
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.fname = 'Patch';
 		user.lname = 'Endpoint';
 		user.username = 'patchEndpoint';
@@ -44,7 +44,7 @@ describe('[Endpoints] Patch', () => {
 		request.params.id = user.id;
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -68,7 +68,7 @@ describe('[Endpoints] Patch', () => {
 		const { request, response } = createMockRequest('PATCH');
 
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.fname = 'Patch';
 		user.lname = 'Endpoint';
 		user.username = 'patchEndpoint2';
@@ -86,7 +86,7 @@ describe('[Endpoints] Patch', () => {
 		request.params.id = user.id;
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 

--- a/test/spec/api/endpoints/post-endpoint.spec.ts
+++ b/test/spec/api/endpoints/post-endpoint.spec.ts
@@ -1,5 +1,5 @@
 import { setModel } from '../../../../src';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { postEndpoint } from '../../../../src/endpoints';
 import { createMockRequest } from '../../../../src/test-probe';
 import { HookTestClass } from '../../../examples/api/models/hook-test-class';
@@ -25,7 +25,7 @@ describe('[Endpoints] Post', () => {
 		const { request, response } = createMockRequest('POST');
 
 		// Create users
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.fname = 'Post';
 		user.lname = 'Endpoint';
 		user.username = 'postEndpoint';
@@ -35,7 +35,7 @@ describe('[Endpoints] Post', () => {
 		request.body = user;
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -58,7 +58,7 @@ describe('[Endpoints] Post', () => {
 		const { request, response } = createMockRequest('POST');
 
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.fname = 'Post';
 		user.lname = 'Endpoint';
 		user.username = 'postEndpoint2';
@@ -68,7 +68,7 @@ describe('[Endpoints] Post', () => {
 		request.body = user;
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -91,14 +91,14 @@ describe('[Endpoints] Post', () => {
 		const { request, response } = createMockRequest('POST');
 
 		// Create users
-		const user1 = new BaseUser();
+		const user1 = new ExampleUser();
 		user1.fname = 'Post';
 		user1.lname = 'Endpoint';
 		user1.username = 'postEndpoint3';
 		user1.password = 'password123';
 		user1.email = 'post3@example.com';
 
-		const user2 = new BaseUser();
+		const user2 = new ExampleUser();
 		user2.fname = 'Post';
 		user2.lname = 'Endpoint';
 		user2.username = 'postEndpoint4';
@@ -108,7 +108,7 @@ describe('[Endpoints] Post', () => {
 		request.body = [ user1, user2 ];
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -131,14 +131,14 @@ describe('[Endpoints] Post', () => {
 		const { request, response } = createMockRequest('POST');
 
 		// Create user
-		const user1 = new BaseUser();
+		const user1 = new ExampleUser();
 		user1.fname = 'Post';
 		user1.lname = 'Endpoint';
 		user1.username = 'postEndpoint5';
 		user1.password = 'password123';
 		user1.email = 'testy';
 
-		const user2 = new BaseUser();
+		const user2 = new ExampleUser();
 		user2.fname = 'Post';
 		user2.lname = 'Endpoint';
 		user2.username = 'postEndpoint6';
@@ -148,7 +148,7 @@ describe('[Endpoints] Post', () => {
 		request.body = [ user1, user2 ];
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 

--- a/test/spec/api/endpoints/refresh-token-endpoint.spec.ts
+++ b/test/spec/api/endpoints/refresh-token-endpoint.spec.ts
@@ -1,7 +1,7 @@
 import { getRepository } from 'typeorm';
 import { hashSync } from 'bcryptjs';
 
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { loginEndpoint, refreshTokenEndpoint } from '../../../../src/endpoints';
 import { createMockRequest } from '../../../../src/test-probe';
 import { jwtBearer } from '../../../../src/jwt-bearer';
@@ -22,14 +22,14 @@ describe('[Endpoints] Refresh Token', async () => {
 
 	beforeAll(async () => {
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.fname = 'RefreshToken';
 		user.lname = 'Test';
 		user.username = 'refreshTokentest';
 		user.password = hashSync('password123', 12);
 		user.email = 'refreshTokentest@example.com';
 
-		await getRepository(BaseUser)
+		await getRepository(ExampleUser)
 			.save(user)
 			.catch((error) => fail(JSON.stringify(error)));
 
@@ -53,7 +53,7 @@ describe('[Endpoints] Refresh Token', async () => {
 
 	it('[Login] can create a refresh token', async () => {
 		if (this.credentials) {
-			expect(this.credentials).toEqual(jasmine.any(BaseUser));
+			expect(this.credentials).toEqual(jasmine.any(ExampleUser));
 			expect('refreshToken' in this.credentials).toBeTruthy();
 			expect('refreshExpiration' in this.credentials).toBeTruthy();
 			expect(typeof this.credentials['refreshToken']).toEqual('string');
@@ -83,7 +83,7 @@ describe('[Endpoints] Refresh Token', async () => {
 		await refreshTokenEndpoint(request, response);
 
 		if (match) {
-			expect(match).toEqual(jasmine.any(BaseUser));
+			expect(match).toEqual(jasmine.any(ExampleUser));
 			expect('token' in match).toBeTruthy();
 			expect('expiration' in match).toBeTruthy();
 			expect(typeof match['token']).toEqual('string');
@@ -118,7 +118,7 @@ describe('[Endpoints] Refresh Token', async () => {
 		// Create mock request/response
 		const { request, response } = createMockRequest();
 
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 0;
 
 		request.body = {

--- a/test/spec/api/endpoints/refresh-token-endpoint.spec.ts
+++ b/test/spec/api/endpoints/refresh-token-endpoint.spec.ts
@@ -71,7 +71,7 @@ describe('[Endpoints] Refresh Token', async () => {
 		const { request, response } = createMockRequest();
 
 		request.body = {
-			refreshToken: this.credentials.refreshToken
+			__refreshToken: this.credentials.refreshToken
 		};
 
 		// Run login endpoint
@@ -99,7 +99,7 @@ describe('[Endpoints] Refresh Token', async () => {
 		const { request, response } = createMockRequest();
 
 		request.body = {
-			refreshToken: 'wrong'
+			__refreshToken: 'wrong'
 		};
 
 		// Run refreshToken endpoint
@@ -122,7 +122,7 @@ describe('[Endpoints] Refresh Token', async () => {
 		user.id = 0;
 
 		request.body = {
-			refreshToken: jwtBearer.sign(user, true)
+			__refreshToken: jwtBearer.sign(user, true)
 		};
 
 		// Run refreshToken endpoint

--- a/test/spec/api/filters/get-filter.spec.ts
+++ b/test/spec/api/filters/get-filter.spec.ts
@@ -1,7 +1,7 @@
 import { getRepository } from 'typeorm';
 
 import { createMockRequest } from '../../../../src/test-probe';
-import { BaseUser, BaseModel } from '../../../../src/models';
+import { ExampleUser, BaseModel } from '../../../../src/models';
 import { getFilter } from '../../../../src/filters';
 import { OnlySelfCanRead, OnlyAdminCanRead } from '../../../../src/bodyguard';
 
@@ -24,14 +24,14 @@ class NobodyCanReadMember extends BaseModel {
 describe('[Guards] getFilter', async () => {
 	beforeAll(async () => {
 		// Create mock user
-		this.user = new BaseUser();
+		this.user = new ExampleUser();
 		this.user.fname = 'tom';
 		this.user.lname = 'doe';
 		this.user.username = 'tomFilter';
 		this.user.email = 'tomFilter@example.com';
 		this.user.password = 'password123';
 
-		await getRepository(BaseUser)
+		await getRepository(ExampleUser)
 			.save(this.user)
 			.catch((error) => fail(error));
 	});
@@ -53,7 +53,7 @@ describe('[Guards] getFilter', async () => {
 		getFilter(request, response, next);
 
 		expect(result).toBe(true);
-		expect(request.payload[0]).toEqual(jasmine.any(BaseUser));
+		expect(request.payload[0]).toEqual(jasmine.any(ExampleUser));
 		expect(request.payload[0].fname).toEqual('tom');
 		expect(request.payload[0].password).toEqual(undefined);
 	});

--- a/test/spec/api/filters/patch-filter.spec.ts
+++ b/test/spec/api/filters/patch-filter.spec.ts
@@ -1,7 +1,7 @@
 import { getRepository } from 'typeorm';
 
 import { createMockRequest } from '../../../../src/test-probe';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { patchFilter } from '../../../../src/filters';
 
 /**
@@ -11,14 +11,14 @@ import { patchFilter } from '../../../../src/filters';
 describe('[Guards] patchFilter', async () => {
 	beforeAll(async () => {
 		// Create mock user
-		this.user = new BaseUser();
+		this.user = new ExampleUser();
 		this.user.fname = 'tom';
 		this.user.lname = 'doe';
 		this.user.username = 'tomFilter3';
 		this.user.email = 'tomFilter3@example.com';
 		this.user.password = 'password123';
 
-		await getRepository(BaseUser)
+		await getRepository(ExampleUser)
 			.save(this.user)
 			.catch((error) => fail(error));
 	});

--- a/test/spec/api/filters/post-filter.spec.ts
+++ b/test/spec/api/filters/post-filter.spec.ts
@@ -1,7 +1,7 @@
 import { getRepository } from 'typeorm';
 
 import { createMockRequest } from '../../../../src/test-probe';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { postFilter } from '../../../../src/filters';
 
 /**
@@ -11,14 +11,14 @@ import { postFilter } from '../../../../src/filters';
 describe('[Guards] postFilter', async () => {
 	beforeAll(async () => {
 		// Create mock user
-		this.user = new BaseUser();
+		this.user = new ExampleUser();
 		this.user.fname = 'tom';
 		this.user.lname = 'doe';
 		this.user.username = 'tomFilter2';
 		this.user.email = 'tomFilter2@example.com';
 		this.user.password = 'password123';
 
-		this.user = await getRepository(BaseUser)
+		this.user = await getRepository(ExampleUser)
 			.save(this.user)
 			.catch((error) => fail(error));
 	});

--- a/test/spec/api/guards/only-active.spec.ts
+++ b/test/spec/api/guards/only-active.spec.ts
@@ -1,5 +1,5 @@
 import { onlyActive } from '../../../../src/guards';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { UserStatus } from '../../../../src/enums';
 
 import { createMockRequest } from '../../../../src/test-probe';
@@ -14,7 +14,7 @@ describe('[Guards] onlyActive', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.status = UserStatus.Active;
 
 		// Test onlyActive()
@@ -51,7 +51,7 @@ describe('[Guards] onlyActive', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.status = UserStatus.Pending;
 
 		// Test onlyActive()

--- a/test/spec/api/guards/only-admin.spec.ts
+++ b/test/spec/api/guards/only-admin.spec.ts
@@ -1,5 +1,5 @@
 import { onlyAdmin } from '../../../../src/guards';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums';
 
 import { createMockRequest } from '../../../../src/test-probe';
@@ -14,7 +14,7 @@ describe('[Guards] onlyAdmin', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.role = UserRole.Admin;
 
 		// Test onlyAdmin()
@@ -51,7 +51,7 @@ describe('[Guards] onlyAdmin', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.role = UserRole.Basic;
 
 		// Test onlyAdmin()

--- a/test/spec/api/guards/only-member.spec.ts
+++ b/test/spec/api/guards/only-member.spec.ts
@@ -1,5 +1,5 @@
 import { onlyMember } from '../../../../src/guards';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums';
 
 import { createMockRequest } from '../../../../src/test-probe';
@@ -14,7 +14,7 @@ describe('[Guards] onlyMember', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.role = UserRole.Member;
 
 		// Test onlyMember()
@@ -51,7 +51,7 @@ describe('[Guards] onlyMember', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.role = UserRole.Basic;
 
 		// Test onlyMember()

--- a/test/spec/api/guards/only-self-delete.spec.ts
+++ b/test/spec/api/guards/only-self-delete.spec.ts
@@ -1,5 +1,5 @@
 import { onlySelf } from '../../../../src/guards';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 
 import { createMockRequest } from '../../../../src/test-probe';
 
@@ -13,7 +13,7 @@ describe('[Guards] onlySelf (Delete)', async () => {
 		const { request, response } = createMockRequest('DELETE');
 
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 1;
 
 		request.user = user;
@@ -37,7 +37,7 @@ describe('[Guards] onlySelf (Delete)', async () => {
 		const { request, response } = createMockRequest('DELETE');
 
 		// Create user
-		request.payload = new BaseUser();
+		request.payload = new ExampleUser();
 		request.payload.id = 1;
 
 		request.params = { id: 1 };
@@ -58,10 +58,10 @@ describe('[Guards] onlySelf (Delete)', async () => {
 		const { request, response } = createMockRequest('DELETE');
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.id = 1;
 
-		request.payload = new BaseUser();
+		request.payload = new ExampleUser();
 		request.payload.id = 2;
 
 		request.params = { id: 2 };

--- a/test/spec/api/guards/only-self-get-many.spec.ts
+++ b/test/spec/api/guards/only-self-get-many.spec.ts
@@ -1,5 +1,5 @@
 import { onlySelf } from '../../../../src/guards';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 
 import { createMockRequest } from '../../../../src/test-probe';
 
@@ -13,7 +13,7 @@ describe('[Guards] onlySelf (Get Many)', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 1;
 
 		request.user = user;
@@ -35,7 +35,7 @@ describe('[Guards] onlySelf (Get Many)', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 1;
 
 		request.payload = [ user ];
@@ -56,10 +56,10 @@ describe('[Guards] onlySelf (Get Many)', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.id = 1;
 
-		const payload = new BaseUser();
+		const payload = new ExampleUser();
 		payload.id = 2;
 
 		request.payload = [ payload ];

--- a/test/spec/api/guards/only-self-get-one.spec.ts
+++ b/test/spec/api/guards/only-self-get-one.spec.ts
@@ -1,5 +1,5 @@
 import { onlySelf } from '../../../../src/guards';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 
 import { createMockRequest } from '../../../../src/test-probe';
 import { UserRole } from '../../../../src/enums';
@@ -14,7 +14,7 @@ describe('[Guards] onlySelf (Get One)', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 1;
 
 		request.user = user;
@@ -38,7 +38,7 @@ describe('[Guards] onlySelf (Get One)', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.payload = new BaseUser();
+		request.payload = new ExampleUser();
 		request.payload.id = 1;
 
 		request.query = { id: 1 };
@@ -59,10 +59,10 @@ describe('[Guards] onlySelf (Get One)', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.id = 1;
 
-		request.payload = new BaseUser();
+		request.payload = new ExampleUser();
 		request.payload.id = 2;
 
 		request.query = { id: 2 };
@@ -83,11 +83,11 @@ describe('[Guards] onlySelf (Get One)', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.id = 1;
 		request.user.role = UserRole.Admin;
 
-		request.payload = new BaseUser();
+		request.payload = new ExampleUser();
 		request.payload.id = 2;
 
 		request.query = { id: 2 };

--- a/test/spec/api/guards/only-self-patch.spec.ts
+++ b/test/spec/api/guards/only-self-patch.spec.ts
@@ -1,5 +1,5 @@
 import { onlySelf } from '../../../../src/guards';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 
 import { createMockRequest } from '../../../../src/test-probe';
 
@@ -13,7 +13,7 @@ describe('[Guards] onlySelf (Patch)', async () => {
 		const { request, response } = createMockRequest('PATCH');
 
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 1;
 
 		request.user = user;
@@ -37,7 +37,7 @@ describe('[Guards] onlySelf (Patch)', async () => {
 		const { request, response } = createMockRequest('PATCH');
 
 		// Create user
-		request.payload = new BaseUser();
+		request.payload = new ExampleUser();
 		request.payload.id = 1;
 
 		request.params = { id: 1 };
@@ -58,10 +58,10 @@ describe('[Guards] onlySelf (Patch)', async () => {
 		const { request, response } = createMockRequest('PATCH');
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.id = 1;
 
-		request.payload = new BaseUser();
+		request.payload = new ExampleUser();
 		request.payload.id = 2;
 
 		request.params = { id: 2 };

--- a/test/spec/api/guards/only-self-post.spec.ts
+++ b/test/spec/api/guards/only-self-post.spec.ts
@@ -1,5 +1,5 @@
 import { onlySelf } from '../../../../src/guards';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 
 import { createMockRequest } from '../../../../src/test-probe';
 
@@ -14,7 +14,7 @@ describe('[Guards] onlySelf (Post)', async () => {
 		request.method = 'POST';
 
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 1;
 
 		request.user = user;
@@ -37,7 +37,7 @@ describe('[Guards] onlySelf (Post)', async () => {
 		request.method = 'POST';
 
 		// Create user
-		request.body = new BaseUser();
+		request.body = new ExampleUser();
 		request.body.id = 1;
 
 		// Test onlySelf()
@@ -57,10 +57,10 @@ describe('[Guards] onlySelf (Post)', async () => {
 		request.method = 'POST';
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.id = 1;
 
-		request.body = new BaseUser();
+		request.body = new ExampleUser();
 		request.body.id = 2;
 
 		// Test onlySelf()

--- a/test/spec/api/guards/only-user.spec.ts
+++ b/test/spec/api/guards/only-user.spec.ts
@@ -1,5 +1,5 @@
 import { onlyUser } from '../../../../src/guards';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums';
 
 import { createMockRequest } from '../../../../src/test-probe';
@@ -14,7 +14,7 @@ describe('[Guards] onlyUser', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 
 		// Test onlyUser()
 		let result = false;

--- a/test/spec/api/handlers/error-handler.spec.ts
+++ b/test/spec/api/handlers/error-handler.spec.ts
@@ -1,7 +1,7 @@
 import { createMockRequest } from '../../../../src/test-probe';
 import { errorHandler } from '../../../../src/handlers';
 import { getRepository } from 'typeorm';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { ExampleOwner } from '../../../examples/api/models/example-owner';
 import { ExampleRelation } from '../../../examples/api/models/example-relation';
 
@@ -61,7 +61,7 @@ describe('[Handlers] errorHandler', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 
 		// Override validation responder
 		let result;
@@ -70,7 +70,7 @@ describe('[Handlers] errorHandler', async () => {
 		};
 
 		// Save user && test error handler
-		await getRepository(BaseUser)
+		await getRepository(ExampleUser)
 			.save(user)
 			.then(() => fail('Saved with null violation'))
 			.catch((error) => {
@@ -131,14 +131,14 @@ describe('[Handlers] errorHandler', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create user
-		const user1 = new BaseUser();
+		const user1 = new ExampleUser();
 		user1.fname = 'tom';
 		user1.lname = 'doe';
 		user1.username = 'tomDuplicate';
 		user1.email = 'tomDuplicate@example.com';
 		user1.password = 'password123';
 
-		const user2 = new BaseUser();
+		const user2 = new ExampleUser();
 		user2.fname = 'tom';
 		user2.lname = 'doe';
 		user2.username = 'tomDuplicate';
@@ -152,7 +152,7 @@ describe('[Handlers] errorHandler', async () => {
 		};
 
 		// Save user && test error handler
-		const repo = getRepository(BaseUser);
+		const repo = getRepository(ExampleUser);
 		await repo.save(user1).catch((error) => fail(error));
 
 		await repo

--- a/test/spec/api/http/http-client.spec.ts
+++ b/test/spec/api/http/http-client.spec.ts
@@ -23,7 +23,7 @@ describe('[HTTP] HTTP Client', () => {
 
 	it('can get', async () => {
 		const result: void | HttpClientResponse = await http
-			.get('/', {}, [ 404 ], 'Bearer: test')
+			.get('/', {}, 'Bearer: test', [ 404 ])
 			.catch((error) => fail(JSON.stringify(error)));
 
 		if (result) {
@@ -38,7 +38,7 @@ describe('[HTTP] HTTP Client', () => {
 		let hasError = false;
 
 		const result: boolean | HttpClientResponse = await http
-			.get('/', {}, [ 200 ])
+			.get('/', {})
 			.catch((error) => (hasError = true));
 
 		expect(hasError).toBe(true);
@@ -46,7 +46,7 @@ describe('[HTTP] HTTP Client', () => {
 
 	it('can post', async () => {
 		const result: void | HttpClientResponse = await http
-			.post('/', {}, [ 404 ], 'Bearer: test')
+			.post('/', {}, 'Bearer: test', [ 404 ])
 			.catch((error) => fail(JSON.stringify(error)));
 
 		if (result) {
@@ -61,7 +61,7 @@ describe('[HTTP] HTTP Client', () => {
 		let hasError = false;
 
 		const result: boolean | HttpClientResponse = await http
-			.post('/', {}, [ 200 ])
+			.post('/', {})
 			.catch((error) => (hasError = true));
 
 		expect(hasError).toBe(true);
@@ -69,7 +69,7 @@ describe('[HTTP] HTTP Client', () => {
 
 	it('can patch', async () => {
 		const result: void | HttpClientResponse = await http
-			.patch('/', {}, [ 404 ], 'Bearer: test')
+			.patch('/', {}, 'Bearer: test', [ 404 ])
 			.catch((error) => fail(JSON.stringify(error)));
 
 		if (result) {
@@ -84,7 +84,7 @@ describe('[HTTP] HTTP Client', () => {
 		let hasError = false;
 
 		const result: boolean | HttpClientResponse = await http
-			.patch('/', {}, [ 200 ])
+			.patch('/', {})
 			.catch((error) => (hasError = true));
 
 		expect(hasError).toBe(true);
@@ -92,7 +92,7 @@ describe('[HTTP] HTTP Client', () => {
 
 	it('can delete', async () => {
 		const result: void | HttpClientResponse = await http
-			.delete('/', [ 404 ], 'Bearer: test')
+			.delete('/', 'Bearer: test', [ 404 ])
 			.catch((error) => fail(JSON.stringify(error)));
 
 		if (result) {
@@ -107,7 +107,7 @@ describe('[HTTP] HTTP Client', () => {
 		let hasError = false;
 
 		const result: boolean | HttpClientResponse = await http
-			.delete('/', [ 200 ])
+			.delete('/')
 			.catch((error) => (hasError = true));
 
 		expect(hasError).toBe(true);

--- a/test/spec/api/jwt-bearer.spec.ts
+++ b/test/spec/api/jwt-bearer.spec.ts
@@ -18,6 +18,17 @@ describe('[JWT]', () => {
 		expect(jwt.key).toBe('test-key');
 	});
 
+	it('can sign a token with a payload', () => {
+		const user = new BaseUser();
+		user.id = 1;
+
+		const jwtString = jwtBearer.sign(user, false, { hasPayload: true });
+		const result = jwtBearer.dryVerify(jwtString);
+
+		expect('hasPayload' in result).toBeTruthy();
+		expect(result.hasPayload).toBeTruthy();
+	});
+
 	it('can can verify a token', () => {
 		const jwtString = jwtBearer.sign(new BaseUser());
 

--- a/test/spec/api/middleware/basic-cors.spec.ts
+++ b/test/spec/api/middleware/basic-cors.spec.ts
@@ -7,7 +7,7 @@ import { createMockRequest } from '../../../../src/test-probe';
  */
 describe('[Middleware] basicCors()', () => {
 	it('sets the headers', () => {
-		delete process.env.CLIENT_URL;
+		delete process.env.ALLOW_ORIGIN;
 		const headers = {};
 		const { request, response } = createMockRequest();
 
@@ -27,8 +27,8 @@ describe('[Middleware] basicCors()', () => {
 		});
 	});
 
-	it('accepts environment CLIENT_URL', () => {
-		process.env.CLIENT_URL = 'test.com';
+	it('accepts environment ALLOW_ORIGIN', () => {
+		process.env.ALLOW_ORIGIN = 'test.com';
 		const headers = {};
 		const { request, response } = createMockRequest();
 
@@ -38,13 +38,13 @@ describe('[Middleware] basicCors()', () => {
 
 		basicCors(request, response, () => {
 			expect(headers['Access-Control-Allow-Origin']).toEqual(
-				process.env.CLIENT_URL
+				process.env.ALLOW_ORIGIN
 			);
 		});
 	});
 
-	it('accepts environment CLIENT_URL as array', () => {
-		process.env.CLIENT_URL = 'test.com, localhost, test2.com';
+	it('accepts environment ALLOW_ORIGIN as array', () => {
+		process.env.ALLOW_ORIGIN = 'test.com, localhost, test2.com';
 		const headers = {};
 		const { request, response } = createMockRequest();
 
@@ -57,8 +57,8 @@ describe('[Middleware] basicCors()', () => {
 		});
 	});
 
-	it('rejects environment CLIENT_URL as array without match', () => {
-		process.env.CLIENT_URL = 'test.com, test2.com';
+	it('rejects environment ALLOW_ORIGIN as array without match', () => {
+		process.env.ALLOW_ORIGIN = 'test.com, test2.com';
 		const headers = {};
 		const { request, response } = createMockRequest();
 

--- a/test/spec/api/middleware/basic-cors.spec.ts
+++ b/test/spec/api/middleware/basic-cors.spec.ts
@@ -53,7 +53,7 @@ describe('[Middleware] basicCors()', () => {
 		};
 
 		basicCors(request, response, () => {
-			expect(headers['Access-Control-Allow-Origin']).toEqual('localhost');
+			expect(headers['Access-Control-Allow-Origin']).toEqual('test.com');
 		});
 	});
 

--- a/test/spec/api/middleware/load-entity.spec.ts
+++ b/test/spec/api/middleware/load-entity.spec.ts
@@ -1,5 +1,5 @@
 import { getRepository } from 'typeorm';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { createMockRequest } from '../../../../src/test-probe';
 import { loadEntity } from '../../../../src/middleware';
 
@@ -10,7 +10,7 @@ import { loadEntity } from '../../../../src/middleware';
 describe('[Middleware] loadEntity()', async () => {
 	beforeAll(async () => {
 		// Create user
-		this.user = new BaseUser();
+		this.user = new ExampleUser();
 		this.user.fname = 'tom';
 		this.user.lname = 'doe';
 		this.user.username = 'tomLoadEntity';
@@ -18,7 +18,7 @@ describe('[Middleware] loadEntity()', async () => {
 		this.user.password = 'password123';
 
 		// Save user
-		await getRepository(BaseUser)
+		await getRepository(ExampleUser)
 			.save(this.user)
 			.catch(() => fail('Could not save user.'));
 	});

--- a/test/spec/api/middleware/load-user.spec.ts
+++ b/test/spec/api/middleware/load-user.spec.ts
@@ -1,5 +1,5 @@
 import { getRepository } from 'typeorm';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { createMockRequest } from '../../../../src/test-probe';
 import { loadUser } from '../../../../src/middleware';
 import { jwtBearer } from '../../../../src/jwt-bearer';
@@ -11,7 +11,7 @@ import { jwtBearer } from '../../../../src/jwt-bearer';
 describe('[Middleware] loadUser()', async () => {
 	beforeAll(async () => {
 		// Create user
-		this.user = new BaseUser();
+		this.user = new ExampleUser();
 		this.user.fname = 'tom';
 		this.user.lname = 'doe';
 		this.user.username = 'tomLoadUser';
@@ -19,7 +19,7 @@ describe('[Middleware] loadUser()', async () => {
 		this.user.password = 'password123';
 
 		// Save user
-		await getRepository(BaseUser)
+		await getRepository(ExampleUser)
 			.save(this.user)
 			.catch((error) =>
 				fail('Could not save user: ' + JSON.stringify(error))
@@ -54,7 +54,7 @@ describe('[Middleware] loadUser()', async () => {
 		const returnValue = await loadUser(request, response, next);
 
 		expect(returnValue).toBe(true);
-		expect(result).toEqual(jasmine.any(BaseUser));
+		expect(result).toEqual(jasmine.any(ExampleUser));
 		expect(result['id']).toEqual(this.user.id);
 	});
 
@@ -91,7 +91,7 @@ describe('[Middleware] loadUser()', async () => {
 		const { request, response } = createMockRequest();
 
 		// Create bad user & token
-		const badUser = new BaseUser();
+		const badUser = new ExampleUser();
 		badUser.id = 99999;
 
 		const badToken = jwtBearer.sign(badUser);

--- a/test/spec/api/pointy-core.spec.ts
+++ b/test/spec/api/pointy-core.spec.ts
@@ -35,6 +35,7 @@ beforeAll(async () => {
 	// Release IPC message interceptor
 	process.send = _send;
 
+	jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 	process.env.PORT = '8081';
 });
 

--- a/test/spec/api/pointy-core.spec.ts
+++ b/test/spec/api/pointy-core.spec.ts
@@ -25,7 +25,15 @@ beforeAll(async () => {
 			);
 	};
 
+	// Intercept IPC messages
+	const _send = process.send;
+	process.send = (message) => (this.ipcMessage = message);
+
+	// Start server
 	await pointy.start();
+
+	// Release IPC message interceptor
+	process.send = _send;
 
 	process.env.PORT = '8081';
 });
@@ -46,5 +54,9 @@ describe('Pointy Core', () => {
 		pointy.app.emit('error', '');
 
 		expect(result).toBe(true);
+	});
+
+	it('sends an ipc message "server-ready"', async () => {
+		expect(this.ipcMessage).toBe('server-ready');
 	});
 });

--- a/test/spec/api/pointy-core.spec.ts
+++ b/test/spec/api/pointy-core.spec.ts
@@ -1,5 +1,5 @@
 import { pointy } from '../../../src/pointy-core';
-import { BaseUser } from '../../../src/models';
+import { ExampleUser } from '../../../src/models';
 import { ExampleOwner } from '../../examples/api/models/example-owner';
 import { ExampleRelation } from '../../examples/api/models/example-relation';
 import { HookTestClass } from '../../examples/api/models/hook-test-class';
@@ -8,13 +8,22 @@ const ROOT_PATH = require('app-root-path').toString();
 
 beforeAll(async () => {
 	// Initialize pointy-core
+	pointy.userType = ExampleUser;
+
 	// Database
-	await pointy.db
-		.setEntities([ BaseUser, ExampleOwner, ExampleRelation, HookTestClass ])
-		.connect(ROOT_PATH)
-		.catch((error) =>
-			fail('Cannot start database' + JSON.stringify(error))
-		);
+	pointy.before = async () => {
+		await pointy.db
+			.setEntities([
+				ExampleUser,
+				ExampleOwner,
+				ExampleRelation,
+				HookTestClass
+			])
+			.connect(ROOT_PATH)
+			.catch((error) =>
+				fail('Cannot start database' + JSON.stringify(error))
+			);
+	};
 
 	await pointy.start();
 

--- a/test/spec/api/pointy-core.spec.ts
+++ b/test/spec/api/pointy-core.spec.ts
@@ -35,7 +35,7 @@ beforeAll(async () => {
 	// Release IPC message interceptor
 	process.send = _send;
 
-	jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+	jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
 	process.env.PORT = '8081';
 });
 

--- a/test/spec/api/query-tools/create-search-query.spec.ts
+++ b/test/spec/api/query-tools/create-search-query.spec.ts
@@ -1,5 +1,5 @@
 import { createSearchQuery } from '../../../../src/utils';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { ExampleRelation } from '../../../examples/api/models/example-relation';
 
 /**
@@ -15,7 +15,10 @@ describe('[Utils] createSearchQuery()', () => {
 			}
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe('(obj.fname=:fname AND obj.lname=:lname)');
 		expect(queryParams).toEqual(query.where);
@@ -29,7 +32,10 @@ describe('[Utils] createSearchQuery()', () => {
 			}
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe('(obj.fname=:fname OR obj.lname=:lname)');
 		expect(queryParams).toEqual(query.whereAnyOf);
@@ -40,11 +46,14 @@ describe('[Utils] createSearchQuery()', () => {
 			search: 'hello world'
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe(
-			'(LOWER(obj.username) LIKE :search OR LOWER(obj.fname) LIKE :search OR' +
-				' LOWER(obj.lname) LIKE :search OR LOWER(obj.email) LIKE :search)'
+			'(LOWER(obj.username) LIKE :search OR LOWER(obj.email) LIKE :search OR' +
+				' LOWER(obj.fname) LIKE :search OR LOWER(obj.lname) LIKE :search)'
 		);
 		expect(queryParams).toEqual({ search: '%hello%world%' });
 	});
@@ -54,7 +63,10 @@ describe('[Utils] createSearchQuery()', () => {
 			search: { fname: 'hello world' }
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe('(LOWER(obj.fname) LIKE :search_fname)');
 		expect(queryParams).toEqual({ search_fname: '%hello%world%' });
@@ -81,7 +93,10 @@ describe('[Utils] createSearchQuery()', () => {
 			}
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe('(obj.id BETWEEN 0 AND 250)');
 		expect(queryParams).toEqual({});
@@ -94,7 +109,10 @@ describe('[Utils] createSearchQuery()', () => {
 			}
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe('obj.id < :id');
 		expect(queryParams).toEqual({ id: '100' });
@@ -107,7 +125,10 @@ describe('[Utils] createSearchQuery()', () => {
 			}
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe('obj.id <= :id');
 		expect(queryParams).toEqual({ id: '100' });
@@ -120,7 +141,10 @@ describe('[Utils] createSearchQuery()', () => {
 			}
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe('obj.id > :id');
 		expect(queryParams).toEqual({ id: '100' });
@@ -133,7 +157,10 @@ describe('[Utils] createSearchQuery()', () => {
 			}
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe('obj.id >= :id');
 		expect(queryParams).toEqual({ id: '100' });
@@ -147,7 +174,10 @@ describe('[Utils] createSearchQuery()', () => {
 			}
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe('obj.fname!=:fname AND obj.lname!=:lname');
 		expect(queryParams).toEqual(query.not);
@@ -164,7 +194,10 @@ describe('[Utils] createSearchQuery()', () => {
 			}
 		};
 
-		const { queryString, queryParams } = createSearchQuery(BaseUser, query);
+		const { queryString, queryParams } = createSearchQuery(
+			ExampleUser,
+			query
+		);
 
 		expect(queryString).toBe(
 			'(obj.status=:status) AND obj.fname!=:fname AND obj.lname!=:lname'

--- a/test/spec/api/query-tools/get-query.spec.ts
+++ b/test/spec/api/query-tools/get-query.spec.ts
@@ -1,7 +1,7 @@
 import { getRepository } from 'typeorm';
 
 import { setModel } from '../../../../src';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { getQuery } from '../../../../src/middleware';
 import { createMockRequest } from '../../../../src/test-probe';
 import { ExampleOwner } from '../../../examples/api/models/example-owner';
@@ -15,14 +15,14 @@ import { UserRole } from '../../../../src/enums';
 describe('[Middleware] GetQuery', () => {
 	beforeAll(async () => {
 		// Create users
-		this.user1 = new BaseUser();
+		this.user1 = new ExampleUser();
 		this.user1.fname = 'Get';
 		this.user1.lname = 'Endpoint';
 		this.user1.username = 'getEndpoint1';
 		this.user1.password = 'password123';
 		this.user1.email = 'get1@example.com';
 
-		this.user2 = new BaseUser();
+		this.user2 = new ExampleUser();
 		this.user2.fname = 'Get';
 		this.user2.lname = 'Endpoint';
 		this.user2.username = 'getEndpoint2';
@@ -30,7 +30,7 @@ describe('[Middleware] GetQuery', () => {
 		this.user2.email = 'get2@example.com';
 
 		// Save users
-		await getRepository(BaseUser)
+		await getRepository(ExampleUser)
 			.save([ this.user1, this.user2 ])
 			.catch((error) =>
 				fail('Could not save users: ' + JSON.stringify(error))
@@ -67,7 +67,7 @@ describe('[Middleware] GetQuery', () => {
 		};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -94,7 +94,7 @@ describe('[Middleware] GetQuery', () => {
 		};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -156,7 +156,7 @@ describe('[Middleware] GetQuery', () => {
 		};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -181,7 +181,7 @@ describe('[Middleware] GetQuery', () => {
 		};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -206,7 +206,7 @@ describe('[Middleware] GetQuery', () => {
 		};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -232,7 +232,7 @@ describe('[Middleware] GetQuery', () => {
 		};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -257,7 +257,7 @@ describe('[Middleware] GetQuery', () => {
 		};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -282,7 +282,7 @@ describe('[Middleware] GetQuery', () => {
 		};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -293,7 +293,7 @@ describe('[Middleware] GetQuery', () => {
 			})
 			.catch((error) => fail('Could not get: ' + JSON.stringify(error)));
 
-		expect(request.payload).toEqual(jasmine.any(BaseUser));
+		expect(request.payload).toEqual(jasmine.any(ExampleUser));
 	});
 
 	it('can get all', async () => {
@@ -305,7 +305,7 @@ describe('[Middleware] GetQuery', () => {
 		request.query = {};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 

--- a/test/spec/api/query-tools/query-validator.spec.ts
+++ b/test/spec/api/query-tools/query-validator.spec.ts
@@ -1,6 +1,6 @@
 import { queryValidator } from '../../../../src/query-tools/query-validator';
 import { createMockRequest } from '../../../../src/test-probe';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 
 /**
  * queryValidator()
@@ -10,8 +10,8 @@ describe('[Utils] queryValidator()', () => {
 	it('returns true if the query is valid', () => {
 		const { request, response } = createMockRequest();
 		request.query = { where: { id: 1 } };
-		request.payloadType = BaseUser;
-		request.payload = new BaseUser();
+		request.payloadType = ExampleUser;
+		request.payload = new ExampleUser();
 
 		let hasValidationResponder = false;
 		response.validationResponder = () => (hasValidationResponder = true);
@@ -27,8 +27,8 @@ describe('[Utils] queryValidator()', () => {
 			not: undefined,
 			join: [ undefined ]
 		};
-		request.payloadType = BaseUser;
-		request.payload = new BaseUser();
+		request.payloadType = ExampleUser;
+		request.payload = new ExampleUser();
 
 		let hasValidationResponder = false;
 		response.validationResponder = () => (hasValidationResponder = true);
@@ -43,8 +43,8 @@ describe('[Utils] queryValidator()', () => {
 	it('fires validation responder if the query type is invalid', () => {
 		const { request, response } = createMockRequest();
 		request.query = { were: { id: 1 } };
-		request.payloadType = BaseUser;
-		request.payload = new BaseUser();
+		request.payloadType = ExampleUser;
+		request.payload = new ExampleUser();
 
 		let hasValidationResponder = false;
 		response.validationResponder = () => (hasValidationResponder = true);
@@ -56,8 +56,8 @@ describe('[Utils] queryValidator()', () => {
 	it('fires validation responder if the query has invalid value type', () => {
 		const { request, response } = createMockRequest();
 		request.query = { where: [ 1 ] };
-		request.payloadType = BaseUser;
-		request.payload = new BaseUser();
+		request.payloadType = ExampleUser;
+		request.payload = new ExampleUser();
 
 		let hasValidationResponder = false;
 		response.validationResponder = () => (hasValidationResponder = true);
@@ -69,8 +69,8 @@ describe('[Utils] queryValidator()', () => {
 	it('fires validation responder if a key is not in the model (object)', () => {
 		const { request, response } = createMockRequest();
 		request.query = { where: { notInModel: 'test' } };
-		request.payloadType = BaseUser;
-		request.payload = new BaseUser();
+		request.payloadType = ExampleUser;
+		request.payload = new ExampleUser();
 
 		let hasValidationResponder = false;
 		response.validationResponder = () => (hasValidationResponder = true);
@@ -82,8 +82,8 @@ describe('[Utils] queryValidator()', () => {
 	it('fires validation responder if a key is not in the model (array)', () => {
 		const { request, response } = createMockRequest();
 		request.query = { join: [ 'notInModel' ] };
-		request.payloadType = BaseUser;
-		request.payload = new BaseUser();
+		request.payloadType = ExampleUser;
+		request.payload = new ExampleUser();
 
 		let hasValidationResponder = false;
 		response.validationResponder = () => (hasValidationResponder = true);
@@ -100,8 +100,8 @@ describe('[Utils] queryValidator()', () => {
 				categories: [ 1, 2, 3 ]
 			}
 		};
-		request.payloadType = BaseUser;
-		request.payload = new BaseUser();
+		request.payloadType = ExampleUser;
+		request.payload = new ExampleUser();
 
 		let hasValidationResponder = false;
 		response.validationResponder = (result) =>

--- a/test/spec/api/set-model.spec.ts
+++ b/test/spec/api/set-model.spec.ts
@@ -1,6 +1,6 @@
 import { createMockRequest } from '../../../src/test-probe';
 import { setModel } from '../../../src';
-import { BaseUser } from '../../../src/models';
+import { ExampleUser } from '../../../src/models';
 import { HookTestClass } from '../../examples/api/models/hook-test-class';
 import { getRepository } from 'typeorm';
 import { addResource } from '../../../src/utils';
@@ -21,14 +21,14 @@ describe('setModel', () => {
 
 	beforeAll(async () => {
 		// Create user
-		this.user = new BaseUser();
+		this.user = new ExampleUser();
 		this.user.fname = 'Set';
 		this.user.lname = 'Model';
 		this.user.username = 'setmodel';
 		this.user.password = 'model';
 		this.user.email = 'setmodel@example.com';
 
-		await getRepository(BaseUser)
+		await getRepository(ExampleUser)
 			.save(this.user)
 			.catch((error) => fail(JSON.stringify(error)));
 	});
@@ -38,12 +38,12 @@ describe('setModel', () => {
 		const { request, response } = createMockRequest('');
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
 		// Expect payload to be a User
-		expect(request.payload).toEqual(jasmine.any(BaseUser));
+		expect(request.payload).toEqual(jasmine.any(ExampleUser));
 	});
 
 	it('sets the identifier', async () => {
@@ -51,7 +51,9 @@ describe('setModel', () => {
 		const { request, response } = createMockRequest('');
 
 		// Set model
-		if (!await setModel(request, response, BaseUser, false, 'username')) {
+		if (
+			!await setModel(request, response, ExampleUser, false, 'username')
+		) {
 			fail('Could not set model');
 		}
 
@@ -62,13 +64,13 @@ describe('setModel', () => {
 	it('sets request.params to request.user on auth delete route', async () => {
 		// Create mock request/response
 		const { request, response } = createMockRequest('DELETE');
-		request.user = new BaseUser();
+		request.user = new ExampleUser();
 		request.user.id = 1;
 
 		response.goneResponder = () => {};
 
 		// Set model
-		await setModel(request, response, BaseUser, true);
+		await setModel(request, response, ExampleUser, true);
 
 		// Expect identifier to have been set
 		expect(request.user).toEqual(request.params);
@@ -82,7 +84,7 @@ describe('setModel', () => {
 		response.unauthorizedResponder = () => (result = true);
 
 		// Set model
-		if (await setModel(request, response, BaseUser, true)) {
+		if (await setModel(request, response, ExampleUser, true)) {
 			fail('Should not set model');
 		}
 
@@ -107,7 +109,7 @@ describe('setModel', () => {
 		];
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 	});
@@ -122,7 +124,7 @@ describe('setModel', () => {
 		};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 	});
@@ -148,7 +150,7 @@ describe('setModel', () => {
 		response.validationResponder = () => (result = true);
 
 		// Set model
-		if (await setModel(request, response, BaseUser)) {
+		if (await setModel(request, response, ExampleUser)) {
 			fail('Should not set model');
 		}
 
@@ -169,7 +171,7 @@ describe('setModel', () => {
 		response.validationResponder = () => (result = true);
 
 		// Set model
-		if (await setModel(request, response, BaseUser)) {
+		if (await setModel(request, response, ExampleUser)) {
 			fail('Should not set model');
 		}
 
@@ -182,7 +184,7 @@ describe('setModel', () => {
 		request.query = {};
 
 		// Set model
-		if (!await setModel(request, response, BaseUser)) {
+		if (!await setModel(request, response, ExampleUser)) {
 			fail('Could not set model');
 		}
 
@@ -203,7 +205,7 @@ describe('setModel', () => {
 		response.validationResponder = () => (result = true);
 
 		// Set model
-		if (await setModel(request, response, BaseUser)) {
+		if (await setModel(request, response, ExampleUser)) {
 			fail('Should not set model');
 		}
 
@@ -224,7 +226,7 @@ describe('setModel', () => {
 		response.validationResponder = () => (result = true);
 
 		// Set model
-		if (await setModel(request, response, BaseUser)) {
+		if (await setModel(request, response, ExampleUser)) {
 			fail('Should not set model');
 		}
 
@@ -240,7 +242,7 @@ describe('setModel', () => {
 		response.goneResponder = () => (result = true);
 
 		// Set model
-		if (await setModel(request, response, BaseUser)) {
+		if (await setModel(request, response, ExampleUser)) {
 			fail('Should not set model');
 		}
 
@@ -256,7 +258,7 @@ describe('setModel', () => {
 		response.goneResponder = () => (result = true);
 
 		// Set model
-		if (await setModel(request, response, BaseUser)) {
+		if (await setModel(request, response, ExampleUser)) {
 			fail('Should not set model');
 		}
 

--- a/test/spec/api/test-probe/create-mock-request.spec.ts
+++ b/test/spec/api/test-probe/create-mock-request.spec.ts
@@ -1,5 +1,5 @@
 import { createMockRequest } from '../../../../src/test-probe';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 
 declare var fail;
 
@@ -22,7 +22,7 @@ describe('[Test Probe] createMockRequest()', () => {
 		expect(request.repository).toEqual(jasmine.any(Object));
 		expect(request.method).toEqual('GET');
 		expect(request.baseUrl).toEqual('/api/v1/user');
-		expect(request.payloadType).toEqual(BaseUser);
+		expect(request.payloadType).toEqual(ExampleUser);
 		expect(request.joinMembers).toEqual(jasmine.any(Array));
 		expect(request.identifier).toEqual('id');
 	});

--- a/test/spec/api/utils/add-resource.spec.ts
+++ b/test/spec/api/utils/add-resource.spec.ts
@@ -1,7 +1,7 @@
 import { hashSync } from 'bcryptjs';
 
 import { addResource } from '../../../../src/utils';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums';
 import { getRepository } from 'typeorm';
 
@@ -19,7 +19,7 @@ describe('[Utils] addResource()', () => {
 	});
 
 	beforeAll(async () => {
-		await addResource(BaseUser, {
+		await addResource(ExampleUser, {
 			fname: 'Drew',
 			lname: 'Immerman',
 			username: 'AddDrew1',
@@ -30,7 +30,7 @@ describe('[Utils] addResource()', () => {
 	});
 
 	it('can add a new resource', async () => {
-		const user = await getRepository(BaseUser)
+		const user = await getRepository(ExampleUser)
 			.findOne({ username: 'AddDrew1' })
 			.catch(fail);
 
@@ -40,7 +40,7 @@ describe('[Utils] addResource()', () => {
 	});
 
 	it('can add an existing resource', async () => {
-		await addResource(BaseUser, {
+		await addResource(ExampleUser, {
 			fname: 'DrewOverride',
 			lname: 'Immerman',
 			username: 'AddDrew1',
@@ -49,7 +49,7 @@ describe('[Utils] addResource()', () => {
 			role: UserRole.Member
 		}).catch(fail);
 
-		const user = await getRepository(BaseUser)
+		const user = await getRepository(ExampleUser)
 			.findOne({ username: 'AddDrew1' })
 			.catch(fail);
 

--- a/test/spec/api/utils/is-admin.spec.ts
+++ b/test/spec/api/utils/is-admin.spec.ts
@@ -1,5 +1,5 @@
 import { isAdmin } from '../../../../src/utils';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums';
 
 /**
@@ -9,7 +9,7 @@ import { UserRole } from '../../../../src/enums';
 describe('[Utils] isAdmin', () => {
 	it('returns true if the user is an admin', () => {
 		// Create admin user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.role = UserRole.Admin;
 
 		// Expect isAdmin() to return true
@@ -18,7 +18,7 @@ describe('[Utils] isAdmin', () => {
 
 	it('returns false if the user is not an admin', () => {
 		// Create basic user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 
 		// Expect isAdmin() to return false
 		expect(isAdmin(user)).toBe(false);

--- a/test/spec/api/utils/is-self.spec.ts
+++ b/test/spec/api/utils/is-self.spec.ts
@@ -1,5 +1,5 @@
 import { isSelf } from '../../../../src/utils';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 
 /**
  * isSelf()
@@ -8,11 +8,11 @@ import { BaseUser } from '../../../../src/models';
 describe('[Utils] isSelf', () => {
 	it('returns true if the user matches the result', () => {
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 2;
 
 		// Check if self
-		const result = isSelf(user, user, BaseUser, BaseUser);
+		const result = isSelf(user, user, ExampleUser, ExampleUser);
 
 		// Expect result to be true
 		expect(result).toBe(true);
@@ -20,11 +20,16 @@ describe('[Utils] isSelf', () => {
 
 	it('returns false if the user does not match the result', () => {
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 2;
 
 		// Check if self
-		const result = isSelf(user, new BaseUser(), BaseUser, BaseUser);
+		const result = isSelf(
+			user,
+			new ExampleUser(),
+			ExampleUser,
+			ExampleUser
+		);
 
 		// Expect result to be false
 		expect(result).toBe(false);
@@ -32,11 +37,11 @@ describe('[Utils] isSelf', () => {
 
 	it('returns true if the user matches all results in array', () => {
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 2;
 
 		// Check if self
-		const result = isSelf([ user ], user, BaseUser, BaseUser);
+		const result = isSelf([ user ], user, ExampleUser, ExampleUser);
 
 		// Expect result to be true
 		expect(result).toBe(true);
@@ -44,11 +49,16 @@ describe('[Utils] isSelf', () => {
 
 	it('returns false if the user does not match all results in array', () => {
 		// Create user
-		const user = new BaseUser();
+		const user = new ExampleUser();
 		user.id = 2;
 
 		// Check if self
-		const result = isSelf([ user ], new BaseUser(), BaseUser, BaseUser);
+		const result = isSelf(
+			[ user ],
+			new ExampleUser(),
+			ExampleUser,
+			ExampleUser
+		);
 
 		// Expect result to be false
 		expect(result).toBe(false);

--- a/test/spec/api/utils/listen.spec.ts
+++ b/test/spec/api/utils/listen.spec.ts
@@ -37,23 +37,4 @@ describe('[Utils] listen()', async () => {
 
 		expect(result).toBe(true);
 	});
-
-	it('sends an ipc message "server-ready"', async () => {
-		const app = {
-			listen: (_, cb) => {
-				cb();
-			}
-		};
-
-		const _send = process.send;
-
-		let result: string;
-		process.send = (message) => (result = message);
-
-		await listen(app, 80, () => {});
-
-		expect(result).toBe('server-ready');
-
-		process.send = _send;
-	});
 });

--- a/test/spec/api/utils/upgrade-user-role.spec.ts
+++ b/test/spec/api/utils/upgrade-user-role.spec.ts
@@ -1,4 +1,4 @@
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums';
 import { upgradeUserRole } from '../../../../src/utils/upgrade-user-role';
 import { getRepository } from 'typeorm';
@@ -10,8 +10,8 @@ import { getRepository } from 'typeorm';
 describe('upgradeUserRole()', () => {
 	beforeAll(async () => {
 		// Create user
-		this.user = new BaseUser();
-		this.user.fname = 'BaseUser';
+		this.user = new ExampleUser();
+		this.user.fname = 'ExampleUser';
 		this.user.lname = 'Upgrade';
 		this.user.username = 'baseUserUpgrade';
 		this.user.password = 'password123';
@@ -19,7 +19,7 @@ describe('upgradeUserRole()', () => {
 		this.user.role = UserRole.Basic;
 
 		// Save user
-		this.user = await getRepository(BaseUser)
+		this.user = await getRepository(ExampleUser)
 			.save(this.user)
 			.catch((error) => fail(JSON.stringify(error)));
 	});
@@ -28,14 +28,14 @@ describe('upgradeUserRole()', () => {
 		// Upgrade role to admin
 		await upgradeUserRole(
 			'baseUserUpgrade',
-			BaseUser,
+			ExampleUser,
 			UserRole.Admin
 		).catch((error) =>
 			fail('Could not upgrade user role: ' + JSON.stringify(error))
 		);
 
 		// Pull user back from database
-		this.user = await getRepository(BaseUser)
+		this.user = await getRepository(ExampleUser)
 			.findOne(this.user.id)
 			.catch((error) => fail(JSON.stringify(error)));
 
@@ -47,7 +47,7 @@ describe('upgradeUserRole()', () => {
 		let result = false;
 
 		// Upgrade role to admin
-		await upgradeUserRole('nobody', BaseUser, UserRole.Admin)
+		await upgradeUserRole('nobody', ExampleUser, UserRole.Admin)
 			.then((error) =>
 				fail('Upgraded nobodies user role: ' + JSON.stringify(error))
 			)

--- a/test/spec/basic/server.spec.ts
+++ b/test/spec/basic/server.spec.ts
@@ -28,13 +28,13 @@ afterAll(() => {
 describe('API Server', () => {
 	it('is running', async () => {
 		await http
-			.get('/', {}, [ 200, 404 ])
+			.get('/', {}, undefined, [ 200, 404 ])
 			.catch((error) => fail(JSON.stringify(error)));
 	});
 
 	it('sends proper headers', async () => {
 		const result = await http
-			.get('/', {}, [ 200, 404 ])
+			.get('/', {}, undefined, [ 200, 404 ])
 			.catch((error) => fail(JSON.stringify(error)));
 
 		if (result) {

--- a/test/spec/basic/user/user-delete.spec.ts
+++ b/test/spec/basic/user/user-delete.spec.ts
@@ -15,7 +15,7 @@ describe('User API Delete', () => {
 
 		if (result) {
 			await http
-				.delete(`/api/v1/user/${result.body['id']}`, [ 204 ])
+				.delete(`/api/v1/user/${result.body['id']}`)
 				.catch((error) => fail(JSON.stringify(error)));
 		}
 	});

--- a/test/spec/basic/user/user-get.spec.ts
+++ b/test/spec/basic/user/user-get.spec.ts
@@ -26,7 +26,7 @@ describe('User API Read', () => {
 
 	it('can read all', async () => {
 		await http
-			.get('/api/v1/user', {}, [ 200 ])
+			.get('/api/v1/user', {})
 			.then((result) => expect(result.body).toEqual(jasmine.any(Array)))
 			.catch((error) => fail(JSON.stringify(error)));
 	});
@@ -64,6 +64,7 @@ describe('User API Read', () => {
 				{
 					id: 12345
 				},
+				undefined,
 				[ 410 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -122,6 +123,7 @@ describe('User API Read', () => {
 				{
 					select: [ 'password' ]
 				},
+				undefined,
 				[ 403 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));

--- a/test/spec/basic/user/user-patch.spec.ts
+++ b/test/spec/basic/user/user-patch.spec.ts
@@ -18,22 +18,14 @@ describe('User API Update', () => {
 
 	it('can update', async () => {
 		await http
-			.patch(
-				`/api/v1/user/${this.user1.body.id}`,
-				{
-					lname: 'testLast'
-				},
-				[ 204 ]
-			)
+			.patch(`/api/v1/user/${this.user1.body.id}`, {
+				lname: 'testLast'
+			})
 			.then((result) => {
 				http
-					.get(
-						`/api/v1/user`,
-						{
-							id: this.user1.body.id
-						},
-						[ 200 ]
-					)
+					.get(`/api/v1/user`, {
+						id: this.user1.body.id
+					})
 					.then((getResult) =>
 						expect(getResult.body['lname']).toEqual('testLast')
 					)
@@ -62,17 +54,14 @@ describe('User API Update', () => {
 					{
 						email: ''
 					},
+					undefined,
 					[ 204 ]
 				)
 				.then((result) => {
 					http
-						.get(
-							`/api/v1/user`,
-							{
-								id: user.body['id']
-							},
-							[ 200 ]
-						)
+						.get(`/api/v1/user`, {
+							id: user.body['id']
+						})
 						.then((getResult) =>
 							expect(getResult.body['email']).toEqual(null)
 						)
@@ -92,17 +81,14 @@ describe('User API Update', () => {
 				{
 					lname: 'testLast'
 				},
+				undefined,
 				[ 204 ]
 			)
 			.then((result) => {
 				http
-					.get(
-						`/api/v1/user`,
-						{
-							id: this.user1.body.id
-						},
-						[ 200 ]
-					)
+					.get(`/api/v1/user`, {
+						id: this.user1.body.id
+					})
 					.then((getResult) =>
 						expect(getResult.body['email']).toEqual(
 							'basicUserPatch1@test.com'
@@ -120,6 +106,7 @@ describe('User API Update', () => {
 				{
 					username: 'tom<tester5'
 				},
+				undefined,
 				[ 400 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -132,6 +119,7 @@ describe('User API Update', () => {
 				{
 					email: 'drew3test.com'
 				},
+				undefined,
 				[ 400 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -139,13 +127,9 @@ describe('User API Update', () => {
 
 	it('removes undefined members', async () => {
 		await http
-			.patch(
-				`/api/v1/user/${this.user1.body.id}`,
-				{
-					biography: undefined
-				},
-				[ 204 ]
-			)
+			.patch(`/api/v1/user/${this.user1.body.id}`, {
+				biography: undefined
+			})
 			.catch((error) => fail(JSON.stringify(error)));
 	});
 });

--- a/test/spec/basic/user/user-post.spec.ts
+++ b/test/spec/basic/user/user-post.spec.ts
@@ -36,6 +36,7 @@ describe('User API Create', () => {
 					password: 'password123',
 					email: 'dupeUserTest1@test.com'
 				},
+				undefined,
 				[ 409 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -52,6 +53,7 @@ describe('User API Create', () => {
 					password: 'password123',
 					email: 'basicPostUser1@test.com'
 				},
+				undefined,
 				[ 409 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -67,6 +69,7 @@ describe('User API Create', () => {
 					password: 'password123',
 					email: 'requiredUser1@test.com'
 				},
+				undefined,
 				[ 400 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -82,6 +85,7 @@ describe('User API Create', () => {
 					username: 'requiredPass1',
 					email: 'requiredPass1@test.com'
 				},
+				undefined,
 				[ 400 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -98,6 +102,7 @@ describe('User API Create', () => {
 					password: 'password123',
 					email: 'invalidUser1@test.com'
 				},
+				undefined,
 				[ 400 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -114,6 +119,7 @@ describe('User API Create', () => {
 					password: 'password123',
 					email: 'drew3test.com'
 				},
+				undefined,
 				[ 400 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -131,6 +137,7 @@ describe('User API Create', () => {
 					email: 'basicPost400@test.com',
 					memberThatDoesNotExist: 'fail'
 				},
+				undefined,
 				[ 400 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -138,18 +145,14 @@ describe('User API Create', () => {
 
 	it('removes undefined members', async () => {
 		await http
-			.post(
-				'/api/v1/user',
-				{
-					fname: 'post400',
-					lname: 'post400',
-					username: 'basicPost400',
-					password: 'password123',
-					email: 'basicPost400@test.com',
-					biography: undefined
-				},
-				[ 200 ]
-			)
+			.post('/api/v1/user', {
+				fname: 'post400',
+				lname: 'post400',
+				username: 'basicPost400',
+				password: 'password123',
+				email: 'basicPost400@test.com',
+				biography: undefined
+			})
 			.catch((error) => fail(JSON.stringify(error)));
 	});
 });

--- a/test/spec/chat/chat/chat-delete.spec.ts
+++ b/test/spec/chat/chat/chat-delete.spec.ts
@@ -86,7 +86,6 @@ describe('[Chat] Chat API Delete', () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.catch((error) =>
@@ -97,7 +96,6 @@ describe('[Chat] Chat API Delete', () => {
 			await http
 				.delete(
 					`/api/v1/chat/${chat.body['id']}`,
-					[ 204 ],
 					this.token.body.token
 				)
 				.catch((error) => fail(JSON.stringify(error)));
@@ -115,14 +113,13 @@ describe('[Chat] Chat API Delete', () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.catch((error) => fail(JSON.stringify(error)));
 
 		if (result) {
 			await http
-				.delete(`/api/v1/chat/${result.body['id']}`, [ 401 ])
+				.delete(`/api/v1/chat/${result.body['id']}`, undefined, [ 401 ])
 				.catch((error) => fail(JSON.stringify(error)));
 		}
 	});
@@ -159,7 +156,6 @@ describe('[Chat] Chat API Delete', () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.catch((error) =>
@@ -171,8 +167,8 @@ describe('[Chat] Chat API Delete', () => {
 			await http
 				.delete(
 					`/api/v1/chat/${chat.body['id']}`,
-					[ 403 ],
-					wrongToken.body['token']
+					wrongToken.body['token'],
+					[ 403 ]
 				)
 				.catch((error) => fail(JSON.stringify(error)));
 		}
@@ -189,7 +185,6 @@ describe('[Chat] Chat API Delete', () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -198,7 +193,6 @@ describe('[Chat] Chat API Delete', () => {
 			await http
 				.delete(
 					`/api/v1/chat/${result.body['id']}`,
-					[ 204 ],
 					this.adminToken.body.token
 				)
 				.catch((error) => fail(JSON.stringify(error)));

--- a/test/spec/chat/chat/chat-get.spec.ts
+++ b/test/spec/chat/chat/chat-get.spec.ts
@@ -53,7 +53,6 @@ describe('[Chat] Chat API Get', async () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.catch((error) =>
@@ -67,7 +66,6 @@ describe('[Chat] Chat API Get', async () => {
 					to: { id: this.user.body.id },
 					body: 'test2'
 				},
-				[ 200 ],
 				this.token2.body.token
 			)
 			.catch((error) =>
@@ -82,7 +80,6 @@ describe('[Chat] Chat API Get', async () => {
 				{
 					id: this.chat.body.id
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {
@@ -99,7 +96,6 @@ describe('[Chat] Chat API Get', async () => {
 				{
 					id: this.chat2.body.id
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {
@@ -116,6 +112,7 @@ describe('[Chat] Chat API Get', async () => {
 				{
 					id: this.chat2.body.id
 				},
+				undefined,
 				[ 401 ]
 			)
 			.catch((error) =>
@@ -150,8 +147,8 @@ describe('[Chat] Chat API Get', async () => {
 				.get(
 					'/api/v1/chat',
 					{ id: this.chat.body['id'] },
-					[ 403 ],
-					wrongToken.body['token']
+					wrongToken.body['token'],
+					[ 403 ]
 				)
 				.catch((error) => fail(JSON.stringify(error)));
 		}
@@ -171,7 +168,6 @@ describe('[Chat] Chat API Get', async () => {
 						from: this.user2.body.id
 					}
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {
@@ -193,7 +189,6 @@ describe('[Chat] Chat API Get', async () => {
 					search: 'chatGet1',
 					join: [ 'inbox' ]
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {
@@ -218,7 +213,6 @@ describe('[Chat] Chat API Get', async () => {
 						from: +this.user.body.id
 					}
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {
@@ -241,7 +235,6 @@ describe('[Chat] Chat API Get', async () => {
 						from: this.user.body.id
 					}
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {
@@ -293,7 +286,6 @@ describe('[Chat] Chat API Get', async () => {
 							from: this.user.body.id
 						}
 					},
-					[ 200 ],
 					token.body['token']
 				)
 				.then((result) => {
@@ -314,7 +306,6 @@ describe('[Chat] Chat API Get', async () => {
 						from: this.user.body.id
 					}
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {
@@ -353,7 +344,6 @@ describe('[Chat] Chat API Get', async () => {
 						to: { id: user.body['id'] },
 						body: 'test'
 					},
-					[ 200 ],
 					token.body['token']
 				)
 				.catch((error) =>
@@ -369,7 +359,6 @@ describe('[Chat] Chat API Get', async () => {
 					{
 						search: 'nestedGet1'
 					},
-					[ 200 ],
 					token.body['token']
 				)
 				.then((result) => {
@@ -401,7 +390,6 @@ describe('[Chat] Chat API Get', async () => {
 						'from.username': 'DESC'
 					}
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {
@@ -439,7 +427,6 @@ describe('[Chat] Chat API Get', async () => {
 						id: 'ASC'
 					}
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {

--- a/test/spec/chat/chat/chat-patch.spec.ts
+++ b/test/spec/chat/chat/chat-patch.spec.ts
@@ -57,7 +57,6 @@ describe('[Chat] Chat API Patch', () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -69,7 +68,6 @@ describe('[Chat] Chat API Patch', () => {
 					{
 						fromStatus: ChatStatus.Read
 					},
-					[ 204 ],
 					this.token.body.token
 				)
 				.catch((error) => fail(JSON.stringify(error)));
@@ -105,7 +103,6 @@ describe('[Chat] Chat API Patch', () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.catch((error) =>
@@ -119,8 +116,8 @@ describe('[Chat] Chat API Patch', () => {
 					{
 						fromStatus: ChatStatus.Read
 					},
-					[ 403 ],
-					wrongToken.body['token']
+					wrongToken.body['token'],
+					[ 403 ]
 				)
 				.catch((error) => fail(JSON.stringify(error)));
 		}
@@ -137,7 +134,6 @@ describe('[Chat] Chat API Patch', () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
-				[ 200, 204 ],
 				this.token.body.token
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -149,7 +145,6 @@ describe('[Chat] Chat API Patch', () => {
 					{
 						booleanTest: true
 					},
-					[ 200, 204 ],
 					this.token.body.token
 				)
 				.catch((error) => fail(JSON.stringify(error)));
@@ -158,7 +153,6 @@ describe('[Chat] Chat API Patch', () => {
 				.get(
 					`/api/v1/chat`,
 					{ id: result.body['id'] },
-					[ 200 ],
 					this.token.body.token
 				)
 				.catch((error) => fail(JSON.stringify(error)));

--- a/test/spec/chat/chat/chat-post.spec.ts
+++ b/test/spec/chat/chat/chat-post.spec.ts
@@ -54,7 +54,6 @@ describe('[Chat] Chat API Post', () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {
@@ -78,7 +77,6 @@ describe('[Chat] Chat API Post', () => {
 						body: 'test array 2'
 					}
 				],
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {
@@ -97,6 +95,7 @@ describe('[Chat] Chat API Post', () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
+				undefined,
 				[ 401 ]
 			)
 			.catch((error) =>
@@ -112,7 +111,6 @@ describe('[Chat] Chat API Post', () => {
 					to: { id: this.user2.body.id },
 					body: 'test'
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.then((result) => {

--- a/test/spec/chat/server.spec.ts
+++ b/test/spec/chat/server.spec.ts
@@ -31,7 +31,7 @@ afterAll(() => {
 describe('API Server', () => {
 	it('is running', async () => {
 		await http
-			.get('/', {}, [ 200, 404 ])
+			.get('/', {}, undefined, [ 200, 404 ])
 			.catch((error) => fail(JSON.stringify(error)));
 	});
 });

--- a/test/spec/guards/auth/auth.spec.ts
+++ b/test/spec/guards/auth/auth.spec.ts
@@ -38,6 +38,7 @@ describe('[Guards] User Api Login/Logout', () => {
 					__user: 'userAuth1',
 					password: 'invalid'
 				},
+				undefined,
 				[ 401 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -45,13 +46,13 @@ describe('[Guards] User Api Login/Logout', () => {
 
 	it('can log out', async () => {
 		await http
-			.delete('/api/v1/auth', [ 204 ], this.token.body.token)
+			.delete('/api/v1/auth', this.token.body.token)
 			.catch((error) => fail(JSON.stringify(error)));
 	});
 
 	it('cannot log out without a token', async () => {
 		await http
-			.delete('/api/v1/auth', [ 401 ])
+			.delete('/api/v1/auth', undefined, [ 401 ])
 			.catch((error) => fail(JSON.stringify(error)));
 	});
 });

--- a/test/spec/guards/server.spec.ts
+++ b/test/spec/guards/server.spec.ts
@@ -2,6 +2,7 @@ import 'jasmine';
 
 import { pointy } from '../../../src/';
 import { forkServer } from '../../../src/utils/fork-server';
+import { ExampleUser } from '../../../src/models';
 const ROOT_PATH = require('app-root-path').toString();
 
 const http = pointy.http;
@@ -13,6 +14,7 @@ beforeAll(async () => {
 
 	// Database
 	await pointy.db
+		.setEntities([ ExampleUser ])
 		.connect(ROOT_PATH)
 		.catch((error) =>
 			fail('Cannot start database' + JSON.stringify(error))

--- a/test/spec/guards/server.spec.ts
+++ b/test/spec/guards/server.spec.ts
@@ -30,7 +30,7 @@ afterAll(() => {
 describe('API Server', () => {
 	it('is running', async () => {
 		await http
-			.get('/', {}, [ 200, 404 ])
+			.get('/', {}, undefined, [ 200, 404 ])
 			.catch((error) => fail(JSON.stringify(error)));
 	});
 });

--- a/test/spec/guards/user/user-delete.spec.ts
+++ b/test/spec/guards/user/user-delete.spec.ts
@@ -1,6 +1,6 @@
 import { pointy } from '../../../../src';
 import { upgradeUserRole } from '../../../../src/utils/upgrade-user-role';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums/user-role';
 
 const http = pointy.http;
@@ -30,7 +30,7 @@ describe('[Guards] User API Delete', () => {
 
 		await upgradeUserRole(
 			'adminGuardDel1',
-			BaseUser,
+			ExampleUser,
 			UserRole.Admin
 		).catch((error) =>
 			fail('Could not upgrade user role' + JSON.stringify(error))

--- a/test/spec/guards/user/user-delete.spec.ts
+++ b/test/spec/guards/user/user-delete.spec.ts
@@ -61,11 +61,7 @@ describe('[Guards] User API Delete', () => {
 
 		if (user && token) {
 			await http
-				.delete(
-					`/api/v1/user/${user.body['id']}`,
-					[ 204 ],
-					token.body['token']
-				)
+				.delete(`/api/v1/user/${user.body['id']}`, token.body['token'])
 				.catch((error) => fail(JSON.stringify(error)));
 		}
 		else {
@@ -86,7 +82,7 @@ describe('[Guards] User API Delete', () => {
 
 		if (result) {
 			await http
-				.delete(`/api/v1/user/${result.body['id']}`, [ 401 ])
+				.delete(`/api/v1/user/${result.body['id']}`, undefined, [ 401 ])
 				.catch((error) => fail(JSON.stringify(error)));
 		}
 	});
@@ -129,8 +125,8 @@ describe('[Guards] User API Delete', () => {
 			await http
 				.delete(
 					`/api/v1/user/${user.body['id']}`,
-					[ 403 ],
-					token.body['token']
+					token.body['token'],
+					[ 403 ]
 				)
 				.catch((error) => fail(JSON.stringify(error)));
 		}
@@ -154,7 +150,6 @@ describe('[Guards] User API Delete', () => {
 			await http
 				.delete(
 					`/api/v1/user/${result.body['id']}`,
-					[ 204 ],
 					this.adminToken.body.token
 				)
 				.catch((error) => fail(JSON.stringify(error)));

--- a/test/spec/guards/user/user-get.spec.ts
+++ b/test/spec/guards/user/user-get.spec.ts
@@ -1,6 +1,6 @@
 import { pointy } from '../../../../src';
 import { upgradeUserRole } from '../../../../src/utils/upgrade-user-role';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 import { UserRole } from '../../../../src/enums/user-role';
 
 const http = pointy.http;
@@ -63,7 +63,7 @@ describe('[Guards] User API Read', () => {
 
 		await upgradeUserRole(
 			'adminGuardGet1',
-			BaseUser,
+			ExampleUser,
 			UserRole.Admin
 		).catch((error) =>
 			fail('Could not upgrade user role' + JSON.stringify(error))

--- a/test/spec/guards/user/user-get.spec.ts
+++ b/test/spec/guards/user/user-get.spec.ts
@@ -72,7 +72,7 @@ describe('[Guards] User API Read', () => {
 
 	it('can read all', async () => {
 		await http
-			.get('/api/v1/user', {}, [ 200 ], this.getUser1Token.body.token)
+			.get('/api/v1/user', {}, this.getUser1Token.body.token)
 			.then((result) => {
 				expect(result.body).toEqual(jasmine.any(Array));
 				expect(result.body['length']).toBeGreaterThanOrEqual(2);
@@ -87,7 +87,6 @@ describe('[Guards] User API Read', () => {
 				{
 					id: this.getUser2.body.id
 				},
-				[ 200 ],
 				this.getUser1Token.body.token
 			)
 			.then((result) => {

--- a/test/spec/guards/user/user-patch.spec.ts
+++ b/test/spec/guards/user/user-patch.spec.ts
@@ -1,7 +1,7 @@
 import { pointy } from '../../../../src';
 import { UserRole } from '../../../../src/enums/user-role';
 import { upgradeUserRole } from '../../../../src/utils/upgrade-user-role';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 
 const http = pointy.http;
 
@@ -19,7 +19,7 @@ describe('[Guards] User API Update', () => {
 				fail('Could not create base user: ' + JSON.stringify(error))
 			);
 
-		await upgradeUserRole('adminGuardPatch1', BaseUser, UserRole.Admin);
+		await upgradeUserRole('adminGuardPatch1', ExampleUser, UserRole.Admin);
 
 		this.adminToken = await http
 			.post('/api/v1/auth', {

--- a/test/spec/guards/user/user-patch.spec.ts
+++ b/test/spec/guards/user/user-patch.spec.ts
@@ -81,19 +81,14 @@ describe('[Guards] User API Update', () => {
 					{
 						fname: 'updatedName'
 					},
-					[ 204 ],
 					token.body['token']
 				)
 				.catch((error) => fail(JSON.stringify(error)));
 
 			const getResult = await http
-				.get(
-					`/api/v1/user`,
-					{
-						id: user.body['id']
-					},
-					[ 200 ]
-				)
+				.get(`/api/v1/user`, {
+					id: user.body['id']
+				})
 				.catch((error) => fail(JSON.stringify(error)));
 
 			if (result && getResult) {
@@ -123,6 +118,7 @@ describe('[Guards] User API Update', () => {
 					{
 						fname: 'noToken'
 					},
+					undefined,
 					[ 401 ]
 				)
 				.catch((error) => fail(JSON.stringify(error)));
@@ -149,8 +145,8 @@ describe('[Guards] User API Update', () => {
 					{
 						fname: 'wrongToken'
 					},
-					[ 403 ],
-					this.token.body.token
+					this.token.body.token,
+					[ 403 ]
 				)
 				.catch((error) => fail(JSON.stringify(error)));
 		}
@@ -166,8 +162,8 @@ describe('[Guards] User API Update', () => {
 				{
 					role: UserRole.Admin
 				},
-				[ 403 ],
-				this.token.body.token
+				this.token.body.token,
+				[ 403 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
 	});
@@ -179,7 +175,6 @@ describe('[Guards] User API Update', () => {
 				{
 					fname: 'adminUpdate'
 				},
-				[ 204 ],
 				this.adminToken.body.token
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -190,7 +185,6 @@ describe('[Guards] User API Update', () => {
 				{
 					id: this.user.body.id
 				},
-				[ 200 ],
 				this.token.body.token
 			)
 			.catch((error) => fail(JSON.stringify(error)));

--- a/test/spec/guards/user/user-post.spec.ts
+++ b/test/spec/guards/user/user-post.spec.ts
@@ -1,7 +1,7 @@
 import { pointy } from '../../../../src';
 import { UserRole } from '../../../../src/enums/user-role';
 import { upgradeUserRole } from '../../../../src/utils/upgrade-user-role';
-import { BaseUser } from '../../../../src/models';
+import { ExampleUser } from '../../../../src/models';
 const http = pointy.http;
 
 describe('[Guards] User API Create', () => {
@@ -20,7 +20,7 @@ describe('[Guards] User API Create', () => {
 
 		await upgradeUserRole(
 			'adminGuardPost1',
-			BaseUser,
+			ExampleUser,
 			UserRole.Admin
 		).catch((error) =>
 			fail('Could not upgrade user role' + JSON.stringify(error))

--- a/test/spec/guards/user/user-post.spec.ts
+++ b/test/spec/guards/user/user-post.spec.ts
@@ -50,6 +50,7 @@ describe('[Guards] User API Create', () => {
 					email: 'postUser1@test.com',
 					role: UserRole.Admin
 				},
+				undefined,
 				[ 403 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -57,37 +58,29 @@ describe('[Guards] User API Create', () => {
 
 	it('can write underscored keys', async () => {
 		await http
-			.post(
-				'/api/v1/user',
-				{
-					fname: 'postUser1',
-					lname: 'postUser1',
-					username: 'postUser1',
-					password: 'password123',
-					email: 'postUser1@test.com',
-					__ignore: 'test',
-					___ignore: 'test'
-				},
-				[ 200 ]
-			)
+			.post('/api/v1/user', {
+				fname: 'postUser1',
+				lname: 'postUser1',
+				username: 'postUser1',
+				password: 'password123',
+				email: 'postUser1@test.com',
+				__ignore: 'test',
+				___ignore: 'test'
+			})
 			.catch((error) => fail(JSON.stringify(error)));
 	});
 
 	it('cannot reveal sensitve fields', async () => {
 		await http
-			.post(
-				'/api/v1/user',
-				{
-					fname: 'sensitveUser1',
-					lname: 'sensitveUser1',
-					username: 'sensitveUser1',
-					password: 'password123',
-					email: 'sensitveUser1@test.com',
-					__ignore: 'test',
-					___ignore: 'test'
-				},
-				[ 200 ]
-			)
+			.post('/api/v1/user', {
+				fname: 'sensitveUser1',
+				lname: 'sensitveUser1',
+				username: 'sensitveUser1',
+				password: 'password123',
+				email: 'sensitveUser1@test.com',
+				__ignore: 'test',
+				___ignore: 'test'
+			})
 			.then((result) => {
 				expect(result.body['username']).toEqual(jasmine.any(String));
 

--- a/test/spec/terms/server.spec.ts
+++ b/test/spec/terms/server.spec.ts
@@ -31,7 +31,7 @@ afterAll(() => {
 describe('API Server', () => {
 	it('is running', async () => {
 		await http
-			.get('/', {}, [ 200, 404 ])
+			.get('/', {}, undefined, [ 200, 404 ])
 			.catch((error) => fail(JSON.stringify(error)));
 	});
 });

--- a/test/spec/terms/term/term-delete.spec.ts
+++ b/test/spec/terms/term/term-delete.spec.ts
@@ -61,7 +61,6 @@ describe('[Term] Delete API', async () => {
 					title: 'Math',
 					description: 'Math'
 				},
-				[ 200 ],
 				this.adminToken.body.token
 			)
 			.catch((error) => {
@@ -72,7 +71,6 @@ describe('[Term] Delete API', async () => {
 			await http
 				.delete(
 					`/api/v1/term/${term.body['id']}`,
-					[ 204 ],
 					this.adminToken.body.token
 				)
 				.catch((error) => fail(JSON.stringify(error)));
@@ -90,7 +88,6 @@ describe('[Term] Delete API', async () => {
 					title: 'Science',
 					description: 'Science'
 				},
-				[ 200 ],
 				this.adminToken.body.token
 			)
 			.catch((error) => {
@@ -101,8 +98,8 @@ describe('[Term] Delete API', async () => {
 			await http
 				.delete(
 					`/api/v1/term/${term.body['id']}`,
-					[ 403 ],
-					this.token.body.token
+					this.token.body.token,
+					[ 403 ]
 				)
 				.catch((error) => fail(JSON.stringify(error)));
 		}

--- a/test/spec/terms/term/term-get.spec.ts
+++ b/test/spec/terms/term/term-get.spec.ts
@@ -43,7 +43,6 @@ describe('[Term] API Read', async () => {
 					title: 'History',
 					description: 'History'
 				},
-				[ 200 ],
 				this.adminToken.body.token
 			)
 			.catch((error) => {
@@ -53,7 +52,7 @@ describe('[Term] API Read', async () => {
 
 	it('allows anyone to read the term', async () => {
 		await http
-			.get('/api/v1/term', {}, [ 200 ])
+			.get('/api/v1/term', {})
 			.then((result) => expect(result.body).toEqual(jasmine.any(Array)))
 			.catch((error) => fail(JSON.stringify(error)));
 	});

--- a/test/spec/terms/term/term-post.spec.ts
+++ b/test/spec/terms/term/term-post.spec.ts
@@ -67,7 +67,6 @@ describe('[Term] Post API', async () => {
 					title: 'Social Studies',
 					description: 'Social Studies'
 				},
-				[ 200 ],
 				this.adminToken.body.token
 			)
 			.then((result) => {
@@ -86,8 +85,8 @@ describe('[Term] Post API', async () => {
 					title: 'Language Arts',
 					description: 'Language Arts'
 				},
-				[ 403 ],
-				this.token.body.token
+				this.token.body.token,
+				[ 403 ]
 			)
 			.catch((error) => fail(JSON.stringify(error)));
 	});

--- a/test/spec/terms/term/term-put.spec.ts
+++ b/test/spec/terms/term/term-put.spec.ts
@@ -66,7 +66,6 @@ describe('[Term] Patch API', async () => {
 					title: 'test',
 					description: 'test'
 				},
-				[ 200 ],
 				this.adminToken.body.token
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -78,7 +77,6 @@ describe('[Term] Patch API', async () => {
 					{
 						description: 'update'
 					},
-					[ 204 ],
 					this.adminToken.body.token
 				)
 				.catch((error) => fail(JSON.stringify(error)));
@@ -96,7 +94,6 @@ describe('[Term] Patch API', async () => {
 					title: 'test2',
 					description: 'test2'
 				},
-				[ 200 ],
 				this.adminToken.body.token
 			)
 			.catch((error) => fail(JSON.stringify(error)));
@@ -108,8 +105,8 @@ describe('[Term] Patch API', async () => {
 					{
 						description: 'update'
 					},
-					[ 403 ],
-					this.token.body.token
+					this.token.body.token,
+					[ 403 ]
 				)
 				.catch((error) => fail(JSON.stringify(error)));
 		}

--- a/test/spec/terms/user/user-get.spec.ts
+++ b/test/spec/terms/user/user-get.spec.ts
@@ -42,7 +42,6 @@ describe('[User] API Read', () => {
 				{
 					title: 'User Term'
 				},
-				[ 200 ],
 				this.adminToken.body.token
 			)
 			.then((result) => {


### PR DESCRIPTION
### Breaking Changes (See migration.md)
- [Issue #179] Swap http expect & token param
- Removed database error handler
- Changed `refreshToken` to `__refreshToken` in post endpoints
- Changed `CLIENT_URL` to `ALLOW_ORIGIN`

### Additions
- Added jwtBearer::sign argument
- Added pointy::testmode
- Added new ipc message test
- Added ExampleUser class
- Added ready-check prior to starting server
- Added BaseDb::conn
- Moved Postgres members to BaseDB

### Fixes
- Error handling
- Fixed a bug which mixed up `JWT_TTL` and `JWT_REFRESH_TTL`
- runHook should log error
- patchEndpoint should merge payload after patch hook
- Login endpoint should check validation
- npm update
- Simplified login endpoint
- Fixed default entities bug
- Moved "server-ready" ipc from listen() to pointy::start()